### PR TITLE
fixed some bugs, optimization

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -93,7 +93,7 @@ enum v7_err v7_append(struct v7 *v7, struct v7_val *arr, struct v7_val *val) {
   *head = prop;
   prop->key = NULL;
   prop->val = val;
-  inc_ref_count(val);
+  INC_REF_COUNT(val);
   return V7_OK;
 }
 

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -428,7 +428,7 @@ V7_PRIVATE void init_crypto(void) {
   SET_METHOD(s_crypto, "sha1_hex", Crypto_sha1_hex);
 
   v7_set_class(&s_crypto, V7_CLASS_OBJECT);
-  inc_ref_count(&s_crypto);
+  INC_REF_COUNT(&s_crypto);
 
   SET_RO_PROP_V(s_global, "Crypto", s_crypto);
 }

--- a/src/internal.h
+++ b/src/internal.h
@@ -454,6 +454,25 @@ extern struct v7_val s_file;
     SET_RO_PROP_V(_obj, _name, _val);                                  \
   } while (0)
 
+#define OBJ_SANITY_CHECK(obj)          \
+  do {                                 \
+    assert((obj) != NULL);             \
+    assert((obj)->ref_count >= 0);     \
+    assert(!(obj)->fl.fl.val_dealloc); \
+  } while (0)
+
+#define INC_REF_COUNT(v) \
+  do {                   \
+    OBJ_SANITY_CHECK(v); \
+    (v)->ref_count++;    \
+  } while (0)
+
+#define DEC_REF_COUNT(v) \
+  do {                   \
+    OBJ_SANITY_CHECK(v); \
+    (v)->ref_count--;    \
+  } while (0)
+
 /* Forward declarations */
 
 V7_PRIVATE struct Reprog *re_compiler(const char *pattern,
@@ -493,7 +512,6 @@ V7_PRIVATE int is_string(const struct v7_val *v);
 V7_PRIVATE enum v7_err toString(struct v7 *v7, struct v7_val *obj);
 V7_PRIVATE void init_standard_constructor(enum v7_class cls, v7_func_t ctor);
 V7_PRIVATE enum v7_err inc_stack(struct v7 *v7, int incr);
-V7_PRIVATE void inc_ref_count(struct v7_val *);
 V7_PRIVATE enum v7_err _prop_func_2_value(struct v7 *v7, struct v7_val **f);
 V7_PRIVATE struct v7_val *make_value(struct v7 *v7, enum v7_type type);
 V7_PRIVATE enum v7_err v7_set2(struct v7 *v7, struct v7_val *obj,

--- a/src/string.c
+++ b/src/string.c
@@ -7,7 +7,7 @@ V7_PRIVATE enum v7_err check_str_re_conv(struct v7 *v7, struct v7_val **arg,
       !(re_fl && instanceof(*arg, &s_constructors[V7_CLASS_REGEXP]))) {
     TRY(toString(v7, *arg));
     *arg = v7_top_val(v7);
-    inc_ref_count(*arg);
+    INC_REF_COUNT(*arg);
     TRY(inc_stack(v7, -2));
     TRY(v7_push(v7, *arg));
   }


### PR DESCRIPTION
OBJ_SANITY_CHECK() и INC_REF_COUNT() преобразованы в макросы и вынесены в internal.h, это сделано для ускорения работы и упрощения отслеживания места, где произошла проблема;
добавлен макрос DEC_REF_COUNT():
пофиксена проблема утечки памяти при некоторых операциях с использованием сеттера;
исправлено преобразование типа при сложении операндов, когда второй является строкой.
