### PR TITLE
Fix regexp expression termination

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -426,10 +426,6 @@ static enum v7_err parse_regex(struct v7 *v7) {
       case 'i':
       case 'm':
         break;
-      case '\0':
-      case '\r':
-      case '\n':
-        THROW(V7_SYNTAX_ERROR);
     }
   }
 

--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -464,10 +464,8 @@ static const char *test_stdlib(void) {
   ASSERT((v = v7_exec(v7, "re = /GET (\\S+) HTTP/; re")) != NULL);
   ASSERT((v = v7_exec(v7, "re = /GET (\\S+) HTTP/;")) != NULL);
   ASSERT((v = v7_exec(v7, "re = /GET (\\S+) HTTP/ ")) != NULL);
-#ifdef TODO /* regexp doesn't parse when last char is EOL */
   ASSERT((v = v7_exec(v7, "re = /GET (\\S+) HTTP/\n")) != NULL);
   ASSERT((v = v7_exec(v7, "re = /GET (\\S+) HTTP/")) != NULL);
-#endif
 
   v7_destroy(&v7);
   return NULL;

--- a/v7.c
+++ b/v7.c
@@ -6624,10 +6624,6 @@ static enum v7_err parse_regex(struct v7 *v7) {
       case 'i':
       case 'm':
         break;
-      case '\0':
-      case '\r':
-      case '\n':
-        THROW(V7_SYNTAX_ERROR);
     }
   }
 


### PR DESCRIPTION
Javascript statements to be terminated by newlines and EOFs.

Tested with:
- node -e 're = /GET (\S+) HTTP/'
