### PR TITLE
Fix String.split with empty string arg

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -390,8 +390,8 @@ V7_PRIVATE enum v7_err Str_slice(struct v7_c_func_arg *cfa) {
 
 V7_PRIVATE enum v7_err Str_split(struct v7_c_func_arg *cfa) {
 #define v7 (cfa->v7) /* Needed for TRY() macro below */
-  struct v7_val *arg = cfa->args[0], *arr = v7_push_new_object(v7);
-  struct Resub sub, sub1;
+  struct v7_val *arg = cfa->args[0], *arr = v7_push_new_object(v7), *v;
+  struct Resub sub;
   int limit = 1000000, elem = 0, i, len;
   unsigned long shift = 0;
 
@@ -402,21 +402,34 @@ V7_PRIVATE enum v7_err Str_split(struct v7_c_func_arg *cfa) {
       limit = cfa->args[1]->v.num;
     if (V7_TYPE_UNDEF != arg->type && V7_TYPE_NULL != arg->type) {
       TRY(check_str_re_conv(v7, &arg, 1));
-      if (arg->v.str.len > 0) {
-        TRY(regex_check_prog(arg));
-        for (; elem < limit && shift < cfa->this_obj->v.str.len; elem++) {
-          if (re_exec(arg->v.str.prog, arg->fl.fl,
-                      cfa->this_obj->v.str.buf + shift, &sub))
-            break;
+      TRY(regex_check_prog(arg));
+      for (; elem < limit && shift < cfa->this_obj->v.str.len; elem++) {
+        if (re_exec(arg->v.str.prog, arg->fl.fl,
+                    cfa->this_obj->v.str.buf + shift, &sub))
+          break;
+
+        if (sub.sub[0].end - sub.sub[0].start == 0) {
+          v7_append(
+              v7, arr,
+              v7_mkv(v7, V7_TYPE_STR, cfa->this_obj->v.str.buf + shift,
+                     1, 1));
+          shift++;
+          } else {
           v7_append(
               v7, arr,
               v7_mkv(v7, V7_TYPE_STR, cfa->this_obj->v.str.buf + shift,
                      sub.sub[0].start - cfa->this_obj->v.str.buf - shift, 1));
-          for (i = 1; i < sub.subexpr_num; i++)
-            v7_append(v7, arr, v7_mkv(v7, V7_TYPE_STR, sub.sub[i].start,
-                                      sub.sub[i].end - sub.sub[i].start, 1));
           shift = sub.sub[0].end - cfa->this_obj->v.str.buf;
-          sub1 = sub;
+        }
+
+        for (i = 1; i < sub.subexpr_num; i++) {
+          if (sub.sub[i].start != NULL) {
+            v = v7_mkv(v7, V7_TYPE_STR, sub.sub[i].start,
+                       sub.sub[i].end - sub.sub[i].start, 1);
+          } else {
+            v = make_value(v7, V7_TYPE_UNDEF);
+          }
+          v7_append(v7, arr, v);
         }
       }
     }

--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -432,10 +432,18 @@ static const char *test_stdlib(void) {
 #endif
   ASSERT((v = v7_exec(v7, "m = 'aa bb cc'.split(); m.length")) != NULL);
   ASSERT(check_num(v7, v, 1.0));
-#ifdef TODO  /* doesn't split at every char */
   ASSERT((v = v7_exec(v7, "m = 'aa bb cc'.split(''); m.length")) != NULL);
   ASSERT(check_num(v7, v, 8.0));
-#endif
+  ASSERT((v = v7_exec(v7, "m = 'aa bb cc'.split(RegExp('')); m.length")) != NULL);
+  ASSERT(check_num(v7, v, 8.0));
+  ASSERT((v = v7_exec(v7, "m = 'aa bb cc'.split(/x*/); m.length")) != NULL);
+  ASSERT(check_num(v7, v, 8.0));
+  ASSERT((v = v7_exec(v7, "m = 'aa bb cc'.split(/(x)*/); m.length")) != NULL);
+  ASSERT(check_num(v7, v, 16.0));
+  ASSERT((v = v7_exec(v7, "m[0]")) != NULL);
+  ASSERT(check_str(v7, v, "a"));
+  ASSERT((v = v7_exec(v7, "m[1]")) != NULL);
+  ASSERT(v7_type(v) == V7_TYPE_UNDEF);
   ASSERT((v = v7_exec(v7, "m = 'aa bb cc'.split(' '); m.length")) != NULL);
   ASSERT(check_num(v7, v, 3.0));
   ASSERT((v = v7_exec(v7, "m = 'aa bb cc'.split(' ', 2); m.length")) != NULL);
@@ -446,10 +454,8 @@ static const char *test_stdlib(void) {
   ASSERT(check_num(v7, v, 2.0));
   ASSERT((v = v7_exec(v7, "'aa bb cc'.substr(0, 4).split(' ')[1]")) != NULL);
   ASSERT(check_str(v7, v, "b"));
-#ifdef TODO  /* doesn't split at every char */
   ASSERT((v = v7_exec(v7, "{z: '123456'}.z.substr(0, 3).split('').length")) != NULL);
   ASSERT(check_num(v7, v, 3.0));
-#endif
   ASSERT((v = v7_exec(v7, "String('hi')")) != NULL);
   ASSERT(check_str(v7, v, "hi"));
 #ifdef TODO /* New operator: Assertion failed: (v7->root_scope.proto == &s_global), function do_exec, file src/util.c, line 557. */


### PR DESCRIPTION
It now returns the input string split at every character.
The same goes for regular expressions that don't match anything.

Also fixed capture groups not matching anything, which should
yield an 'undefined' value instead of an empty string.

Standard ref: http://www.ecma-international.org/ecma-262/5.1/#sec-15.5.4.14
Enabled previously failing unit tests and added more tests.
Output compared with node (V8).
