### PR TITLE
Fix 'new' operator for String

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -10,7 +10,6 @@ V7_PRIVATE enum v7_err String_ctor(struct v7_c_func_arg *cfa) {
   const char *str = NULL;
   size_t len = 0;
   int own = 0;
-  struct v7_val *obj = cfa->this_obj;
 
   if (cfa->num_args > 0) {
     struct v7_val *arg = cfa->args[0];
@@ -20,6 +19,7 @@ V7_PRIVATE enum v7_err String_ctor(struct v7_c_func_arg *cfa) {
     own = 1;
   }
   if (cfa->called_as_constructor) {
+    struct v7_val *obj = v7_push_new_object(v7);
     v7_init_str(obj, str, len, own);
     v7_set_class(obj, V7_CLASS_STRING);
   } else

--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -459,9 +459,7 @@ static const char *test_stdlib(void) {
   ASSERT(check_num(v7, v, 3.0));
   ASSERT((v = v7_exec(v7, "String('hi')")) != NULL);
   ASSERT(check_str(v7, v, "hi"));
-#ifdef TODO /* Bug #6: (New operator) Assertion failed: (v7->root_scope.proto == &s_global), function do_exec, file src/util.c, line 557. */
   ASSERT((v = v7_exec(v7, "new String('blah')")) != NULL);
-#endif
 
   /* Math */
   ASSERT((v = v7_exec(v7, "Math.sqrt(144)")) != NULL);

--- a/v7.c
+++ b/v7.c
@@ -5345,7 +5345,6 @@ V7_PRIVATE enum v7_err String_ctor(struct v7_c_func_arg *cfa) {
   const char *str = NULL;
   size_t len = 0;
   int own = 0;
-  struct v7_val *obj = cfa->this_obj;
 
   if (cfa->num_args > 0) {
     struct v7_val *arg = cfa->args[0];
@@ -5355,6 +5354,7 @@ V7_PRIVATE enum v7_err String_ctor(struct v7_c_func_arg *cfa) {
     own = 1;
   }
   if (cfa->called_as_constructor) {
+    struct v7_val *obj = v7_push_new_object(v7);
     v7_init_str(obj, str, len, own);
     v7_set_class(obj, V7_CLASS_STRING);
   } else


### PR DESCRIPTION
It was setting the string proto to the global scope proto
instead of creating a new object.
