### PR TITLE
Add MSBuild project file for building on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ SOURCES = src/global_vars.c src/util.c src/crypto.c src/array.c src/boolean.c \
 all: v7 unit_test
 
 v7.c: src/v7_license.h src/utf.h src/internal.h $(SOURCES) v7.h Makefile
-	cat src/v7_license.h src/utf.h src/internal.h $(SOURCES) | sed -E '/#include .(v7_license|utf|internal).h./d' > $@
+	cat src/v7_license.h src/utf.h src/internal.h $(SOURCES) | sed -E '/#include .(v7_license|utf|internal).h./d' | sed -E 's:#include "..\/v7.h":#include "v7.h":' > $@
 
 v: unit_test
 	valgrind -q --leak-check=full --show-reachable=yes \

--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -23,8 +23,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "v7.h"
-#include "internal.h"
+#include "../v7.h"
+#include "../src/internal.h"
 
 #ifdef _WIN32
 #define isinf(x) (!_finite(x))

--- a/v7.c
+++ b/v7.c
@@ -95,7 +95,7 @@ char* utfutf(char *s1, char *s2);
 #ifndef V7_INTERNAL_H_INCLUDED
 #define V7_INTERNAL_H_INCLUDED
 
-#include "../v7.h"
+#include "v7.h"
 
 #include <sys/stat.h>
 #include <assert.h>

--- a/v7.proj
+++ b/v7.proj
@@ -1,0 +1,32 @@
+<Project DefaultTargets="Build" xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+  <ItemGroup>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>V7_PRIVATE=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.default.props" />
+  <PropertyGroup>
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ItemGroup>
+    <ClCompile Include="v7.c" />
+    <ClCompile Include="tests\unit_test.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="v7.h" />
+    <ClInclude Include="internal\v7.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Targets" />
+</Project>


### PR DESCRIPTION
Run tests with:

   msbuild /t:run

Intended to be used by the windows continuous integration server.
