### PR TITLE
Remove undefined token

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -510,9 +510,6 @@ static enum v7_err parse_precedence_0(struct v7 *v7) {
     case TOK_NULL:
       if (ex) TRY(v7_make_and_push(v7, V7_TYPE_NULL));
       break;
-    case TOK_UNDEFINED:
-      if (ex) TRY(v7_make_and_push(v7, V7_TYPE_UNDEF));
-      break;
     case TOK_TRUE:
       if (ex) TRY(push_bool(v7, 1));
       break;

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -18,8 +18,8 @@ static struct v7_vec s_keywords[] = {
     V7_VEC("instanceof"), V7_VEC("new"),       V7_VEC("null"),
     V7_VEC("return"),     V7_VEC("switch"),    V7_VEC("this"),
     V7_VEC("throw"),      V7_VEC("true"),      V7_VEC("try"),
-    V7_VEC("typeof"),     V7_VEC("undefined"), V7_VEC("var"),
-    V7_VEC("void"),       V7_VEC("while"),     V7_VEC("with")};
+    V7_VEC("typeof"),     V7_VEC("var"),       V7_VEC("void"),
+    V7_VEC("while"),      V7_VEC("with")};
 
 /*
  * Move ptr to the next token, skipping comments and whitespaces.
@@ -220,7 +220,7 @@ V7_PRIVATE enum v7_tok get_tok(const char **s, double *n) {
       return kw(p, *s - p, 5, TOK_THIS);
     case 'u':
       ident(s);
-      return kw(p, *s - p, 1, TOK_UNDEFINED);
+      return TOK_IDENTIFIER;
     case 'v':
       ident(s);
       return kw(p, *s - p, 2, TOK_VAR);

--- a/src/tokenizer.h
+++ b/src/tokenizer.h
@@ -91,7 +91,6 @@ enum v7_tok {
   TOK_TRUE,
   TOK_TRY,
   TOK_TYPEOF,
-  TOK_UNDEFINED,
   TOK_VAR,
   TOK_VOID,
   TOK_WHILE,

--- a/v7.c
+++ b/v7.c
@@ -180,7 +180,6 @@ enum v7_tok {
   TOK_TRUE,
   TOK_TRY,
   TOK_TYPEOF,
-  TOK_UNDEFINED,
   TOK_VAR,
   TOK_VOID,
   TOK_WHILE,
@@ -6805,9 +6804,6 @@ static enum v7_err parse_precedence_0(struct v7 *v7) {
     case TOK_NULL:
       if (ex) TRY(v7_make_and_push(v7, V7_TYPE_NULL));
       break;
-    case TOK_UNDEFINED:
-      if (ex) TRY(v7_make_and_push(v7, V7_TYPE_UNDEF));
-      break;
     case TOK_TRUE:
       if (ex) TRY(push_bool(v7, 1));
       break;
@@ -7690,8 +7686,8 @@ static struct v7_vec s_keywords[] = {
     V7_VEC("instanceof"), V7_VEC("new"),       V7_VEC("null"),
     V7_VEC("return"),     V7_VEC("switch"),    V7_VEC("this"),
     V7_VEC("throw"),      V7_VEC("true"),      V7_VEC("try"),
-    V7_VEC("typeof"),     V7_VEC("undefined"), V7_VEC("var"),
-    V7_VEC("void"),       V7_VEC("while"),     V7_VEC("with")};
+    V7_VEC("typeof"),     V7_VEC("var"),       V7_VEC("void"),
+    V7_VEC("while"),      V7_VEC("with")};
 
 /*
  * Move ptr to the next token, skipping comments and whitespaces.
@@ -7892,7 +7888,7 @@ V7_PRIVATE enum v7_tok get_tok(const char **s, double *n) {
       return kw(p, *s - p, 5, TOK_THIS);
     case 'u':
       ident(s);
-      return kw(p, *s - p, 1, TOK_UNDEFINED);
+      return TOK_IDENTIFIER;
     case 'v':
       ident(s);
       return kw(p, *s - p, 2, TOK_VAR);


### PR DESCRIPTION
Ecma tests test for `var undefined = 1`.
The actual execution of this assignment is ignored,
but we should not treat this as reserved word token because it's not.

Not bothering fixing `parser.c` since reimplementation with AST is on its way.
