### PR TITLE
Removed `SAVE_AST` definition from sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,11 @@ xrun: unit_test
 run: unit_test
 	./unit_test $(TEST_FILTER)
 
+save_want_ast:
+	@rm -f unit_test
+	$(MAKE) run TEST_FILTER=aparser CFLAGS_EXTRA=-DSAVE_AST
+	@rm -f unit_test
+
 all_warnings: v7.c
 	$(CC) v7.c tests/unit_test.c -o $@ -Weverything -Werror $(CFLAGS)
 	./$@

--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -786,10 +786,7 @@ static const char *test_aparser(void) {
   size_t want_ast_len;
   ast_init(&a, 0);
 
-#if 0
-#define SAVE_AST
-#endif
-
+  /* Save with `make save_want_ast` */
 #ifndef SAVE_AST
 
   ASSERT((fp = fopen(want_ast_db, "r")) != NULL);


### PR DESCRIPTION
Sometimes we forget to remove it, and thus some changes in
AST generation or rendering might go unnoticed.

This change adds a `make save_want_ast` target that
runs the test with AST saving enabled.
