### PR TITLE
Use the nice `test.mk` we have in fossa

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,19 @@
 WARNS = -W -Wall -pedantic -Wno-comment -Wno-variadic-macros
 V7_FLAGS = -I./src -I.
 CFLAGS = $(WARNS) -g -O0 -lm $(PROF) $(V7_FLAGS) $(CFLAGS_EXTRA)
-SOURCES = src/global_vars.c src/util.c src/crypto.c src/array.c src/boolean.c \
-          src/date.c src/error.c src/function.c src/math.c src/number.c \
-          src/object.c src/regex.c src/rune.c src/runetype.c src/string.c \
-          src/json.c src/stdlib.c src/parser.c src/tokenizer.c src/api.c \
-          src/ast.c src/vm.c src/aparser.c src/interpreter.c src/slre.c src/main.c
-HEADERS = src/license.h src/utf.h src/tokenizer.h src/vm.h src/internal.h \
-					src/global_vars.h src/slre.h src/ast.h src/aparser.h src/interpreter.h
+
+SRC_DIR=src
+TOP_SOURCES=$(addprefix $(SRC_DIR)/, $(SOURCES))
+TOP_HEADERS=$(addprefix $(SRC_DIR)/, $(HEADERS))
+
+include src/sources.mk
 
 .PHONY: cpplint
 
 all: v7 amalgamated_v7 unit_test
 
-v7.c: $(HEADERS) $(SOURCES) v7.h Makefile
-	cat v7.h $(HEADERS) $(SOURCES) | sed -E "/#include .*(v7.h|`echo $(HEADERS) | sed -e 's,src/,,g' -e 's, ,|,g'`)/d" > $@
+v7.c: $(TOP_HEADERS) $(TOP_SOURCES) v7.h Makefile
+	cat v7.h $(TOP_HEADERS) $(TOP_SOURCES) | sed -E "/#include .*(v7.h|`echo $(TOP_HEADERS) | sed -e 's,src/,,g' -e 's, ,|,g'`)/d" > $@
 
 v: unit_test
 	valgrind -q --leak-check=full --show-reachable=yes \
@@ -22,28 +21,20 @@ v: unit_test
 #	valgrind -q --leak-check=full ./v7 tests/run_tests.js
 #	gcov -a unit_test.c
 
-unit_test: $(SOURCES) $(HEADERS) tests/unit_test.c v7.h Makefile
-	$(CC) $(SOURCES) tests/unit_test.c -o $@ -DV7_EXPOSE_PRIVATE $(CFLAGS)
-
 xrun: unit_test
 	$(CC) -W -Wall -I. -I./src src/tokenizer.c -DTEST_RUN -DV7_EXPOSE_PRIVATE -o t
 	./t
 
-run: unit_test
-	./unit_test $(TEST_FILTER)
-
-save_want_ast:
-	@rm -f unit_test
-	$(MAKE) run TEST_FILTER=aparser CFLAGS_EXTRA=-DSAVE_AST
-	@rm -f unit_test
+run:
+	@$(MAKE) -C tests coverage
 
 all_warnings: v7.c
 	$(CC) v7.c tests/unit_test.c -o $@ -Weverything -Werror $(CFLAGS)
 	./$@
 
-v7: $(HEADERS) $(SOURCES) v7.h
-	$(CC) $(SOURCES) -o $@ -DV7_EXE -DV7_EXPOSE_PRIVATE $(CFLAGS) -lm
-#	$(CC) $(SOURCES) -o $@ -DV7_EXE $(CFLAGS) -lm
+v7: $(TOP_HEADERS) $(TOP_SOURCES) v7.h
+	$(CC) $(TOP_SOURCES) -o $@ -DV7_EXE -DV7_EXPOSE_PRIVATE $(CFLAGS) -lm
+#	$(CC) $(TOP_SOURCES) -o $@ -DV7_EXE $(CFLAGS) -lm
 
 amalgamated_v7: v7.h v7.c
 	$(CC) v7.c -o $@ -DV7_EXE -DV7_EXPOSE_PRIVATE $(CFLAGS) -lm
@@ -56,7 +47,7 @@ t: v7
 	./v7 tests/run_ecma262_tests.js
 
 w: v7.c
-	wine cl tests/unit_test.c $(SOURCES) $(V7_FLAGS) /Zi -DV7_EXPOSE_PRIVATE
+	wine cl tests/unit_test.c $(TOP_SOURCES) $(V7_FLAGS) /Zi -DV7_EXPOSE_PRIVATE
 	wine unit_test.exe
 
 clean:
@@ -72,7 +63,8 @@ difftest:
 	rm $$TMP
 
 cpplint:
+	@(MAKE) -C tests cpplint
 	cpplint.py --verbose=0 --extensions=c,h src/*.[ch] v7.h 2>&1 >/dev/null| grep -v "Done processing" | grep -v "file excluded by"
 
 docker:
-	docker run --rm -v $(CURDIR)/..:/cesanta cesanta/v7_test
+	@(MAKE) -C tests docker

--- a/src/sources.mk
+++ b/src/sources.mk
@@ -1,0 +1,7 @@
+SOURCES = global_vars.c util.c crypto.c array.c boolean.c \
+          date.c error.c function.c math.c number.c \
+          object.c regex.c rune.c runetype.c string.c \
+          json.c stdlib.c parser.c tokenizer.c api.c \
+          ast.c vm.c aparser.c interpreter.c slre.c main.c
+HEADERS = license.h utf.h tokenizer.h vm.h internal.h \
+					global_vars.h slre.h ast.h aparser.h interpreter.h

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,14 @@
+unit_test_cxx
+unit_test_ansi
+unit_test_c99
+unit_test_c11
+unit_test_gcov
+unit_test_valgrind
+unit_test_asan
+*.gcov
+*.gcno
+*.gcda
+*.gcov
+*.dSYM
+lcov.info
+lcov

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,21 @@
+PROG = unit_test
+SRC_DIR=../src
+WARNS = -W -Wall -Wno-comment -Wno-variadic-macros
+V7_FLAGS = -I$(SRC_DIR) -I. -DV7_EXPOSE_PRIVATE
+CFLAGS = $(WARNS) -g -O0 $(V7_FLAGS) $(CFLAGS_EXTRA)
+LDFLAGS = -lm
+AMALGAMATED_SOURCES = ../v7.c
+
+include test.mk
+include $(SRC_DIR)/sources.mk
+
+save_want_ast:
+	@rm -f unit_test
+	$(MAKE) test_c99 TEST_FILTER=aparser CFLAGS_EXTRA=-DSAVE_AST
+	@rm -f unit_test
+
+# Interactive:
+#   docker run -v $(CURDIR)/../..:/cesanta -t -i --entrypoint=/bin/bash cesanta/v7_test
+docker:
+	docker run --rm -v $(CURDIR)/../..:/cesanta cesanta/v7_test
+

--- a/tests/test.mk
+++ b/tests/test.mk
@@ -1,0 +1,132 @@
+# Copyright (c) 2014 Cesanta Software Limited
+# All rights reserved
+#
+# = Requires:
+#
+# - SRC_DIR = path to directory with source files
+# - AMALGAMATED_SOURCES = path to amalgamated C file(s)
+# - PROG = name of main unit test source file
+#
+# - CFLAGS = default compiler flags
+# - LDFLAGS = default linker flags
+#
+# = Parameters:
+#
+# - V=1 -> show commandlines of executed commands
+# - TEST_FILTER -> test name (substring match)
+# - CMD -> run wrapped in cmd (e.g. make test_cxx CMD=lldb)
+#
+# = Useful targets
+#
+# - compile:   perform a very fast syntax check for all dialects
+# - presubmit: suggested presubmit tests
+# - cpplint:   run the linter
+# - lcov:      generate coverage HTML in test/lcov/index.html
+# - test_asan: run with AddressSanitizer
+# - test_valgrind: run with valgrind
+
+CLANG:=clang
+
+# OSX clang doesn't build ASAN. Use brew:
+#  $ brew tap homebrew/versions
+#  $ brew install llvm35 --with-clang --with-asan
+ifneq ("$(wildcard /usr/local/bin/clang-3.5)","")
+	CLANG:=/usr/local/bin/clang-3.5
+endif
+
+PEDANTIC=$(shell gcc --version 2>/dev/null | grep -q clang && echo -pedantic)
+
+###
+
+# TODO(mkm) fix cxx issues. This file should be the same file used in fossa
+# and we should keep it in sync with subtree or something.
+#DIALECTS=cxx ansi c99 c11
+DIALECTS=ansi c99 c11
+SPECIALS=asan gcov valgrind
+
+# Each test target might require either a different compiler name
+# a compiler flag, or a wrapper to be invoked before executing the test
+# they can be overriden here with <VAR>_<target>
+#
+# Vars are:
+# - CC: compiler
+# - CFLAGS: flags passed to the compiler, useful to set dialect and to disable incompatible tests
+# - LDFLAGS: flags passed to the compiler only when linking (e.g. not in syntax only)
+# - SOURCES: non-test source files. To be overriden if needs to build on non amalgamated files
+# - CMD: command wrapper or env variables required to run the test binary
+
+CMD=MallocLogFile=/dev/null
+
+CC_cxx=$(CXX)
+CFLAGS_cxx=-x c++
+
+CFLAGS_ansi=$(PEDANTIC) -ansi
+CFLAGS_c99=$(PEDANTIC) -std=c99
+
+CFLAGS_gcov=$(PEDANTIC) -std=c99 -fprofile-arcs -ftest-coverage
+SOURCES_gcov=$(addprefix $(SRC_DIR)/, $(SOURCES))
+
+CC_asan=$(CLANG)
+CFLAGS_asan=-fsanitize=address -fcolor-diagnostics -std=c99 -DNO_DNS_TEST -UNS_ENABLE_SSL
+CMD_asan=ASAN_SYMBOLIZER_PATH=/usr/local/bin/llvm-symbolizer-3.5 ASAN_OPTIONS=allocator_may_return_null=1,symbolize=1 $(CMD)
+
+CMD_valgrind=valgrind
+
+###
+
+SHELL := /bin/bash
+
+SUFFIXES=$(DIALECTS) $(SPECIALS)
+
+ALL_PROGS=$(foreach p,$(SUFFIXES),$(PROG)-$(p))
+ALL_TESTS=$(foreach p,$(SUFFIXES),test_$(p))
+SHORT_TESTS=$(foreach p,$(DIALECTS),test_$(p))
+
+all: clean compile $(SHORT_TESTS)
+alltests: $(ALL_TESTS) lcov cpplint
+
+# currently both valgrind and asan tests are failing for some test cases
+# it's still useful to be able to run asan/valgrind on some specific test cases
+# but we don't enforce them for presubmit until they are stable again.
+presubmit: $(SHORT_TESTS) cpplint
+
+.PHONY: clean clean_coverage lcov valgrind docker cpplint
+ifneq ($(V), 1)
+.SILENT: $(ALL_PROGS) $(ALL_TESTS)
+endif
+
+compile:
+	@make -j8 $(foreach p,$(DIALECTS),$(PROG)-$(p)) CFLAGS_EXTRA=-fsyntax-only LDFLAGS=
+
+# HACK: cannot have two underscores
+$(PROG)-%: Makefile $(PROG).c $(or $(SOURCES_$*), $(AMALGAMATED_SOURCES))
+	@echo -e "CC\t$(PROG)_$*"
+	$(or $(CC_$*), $(CC)) $(CFLAGS_$*) $(PROG).c $(or $(SOURCES_$*), $(AMALGAMATED_SOURCES)) -o $(PROG)_$* $(CFLAGS) $(LDFLAGS)
+
+$(ALL_TESTS): test_%: Makefile $(PROG)-%
+	@echo -e "RUN\t$(PROG)_$* $(TEST_FILTER)"
+	@$(or $(CMD_$*), $(CMD)) ./$(PROG)_$* $(TEST_FILTER)
+
+coverage: Makefile clean_coverage test_gcov
+	@echo -e "RUN\tGCOV"
+	@gcov -p $(PROG).c $(notdir $(SOURCES)) >/dev/null
+
+test_leaks: Makefile
+	$(MAKE) test_valgrind CMD_valgrind="$(CMD_valgrind) --leak-check=full"
+
+lcov: clean coverage
+	@echo -e "RUN\tlcov"
+	@lcov -q -o lcov.info -c -d . 2>/dev/null
+	@genhtml -q -o lcov lcov.info
+
+cpplint:
+	@echo -e "RUN\tcpplint"
+	@cpplint.py --verbose=0 --extensions=c,h $(SRC_DIR)/*.[ch] 2>&1 >/dev/null| grep -v "Done processing" | grep -v "file excluded by"
+
+clean: clean_coverage
+	@echo -e "CLEAN\tall"
+	@rm -rf $(PROG) $(PROG)_ansi $(PROG)_c99 $(PROG)_gcov $(PROG)_asan $(PROG)_cxx $(PROG)_valgrind lcov.info *.txt *.exe *.obj *.o a.out *.pdb *.opt
+
+clean_coverage:
+	@echo -e "CLEAN\tcoverage"
+	@rm -rf *.gc* *.dSYM index.html

--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -862,7 +862,7 @@ static const char *test_aparser(void) {
     "({, a: 0})",
   };
   FILE *fp;
-  const char *want_ast_db = "tests/want_ast.db";
+  const char *want_ast_db = "want_ast.db";
   char got_ast[102400];
   char want_ast[102400];
   char *next_want_ast = want_ast - 1;
@@ -958,7 +958,7 @@ static const char *test_ecmac(void) {
   struct ast a;
   int i;
   size_t db_len;
-  char *db = read_file("tests/ecmac.db", &db_len);
+  char *db = read_file("ecmac.db", &db_len);
   char *next_case = db - 1;
 
   ast_init(&a, 0);


### PR DESCRIPTION
In fossa we gradually ended up with a few nice things in the
makefile, let's reuse them here:
- ASAN
- GCOV and LCOV
- multiple dialects
- quick parallel dialect syntax check

This change is a little bit rough, since some stuff remains in the main
file. The idea is to use the same `test.mk` file here and in fossa,
so any refactorings should keep that in mind.

For now v7 fails C++ compilation, disabling cxx dialect for now and fixing
in another PR.
