### PR TITLE
Enable POSIX IEEE 1003.1-2008

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,8 @@ difftest:
 	rm $$TMP
 
 cpplint:
-	@(MAKE) -C tests cpplint
+	@$(MAKE) -C tests cpplint
 	cpplint.py --verbose=0 --extensions=c,h src/*.[ch] v7.h 2>&1 >/dev/null| grep -v "Done processing" | grep -v "file excluded by"
 
 docker:
-	@(MAKE) -C tests docker
+	@$(MAKE) -C tests docker

--- a/src/internal.h
+++ b/src/internal.h
@@ -13,6 +13,8 @@
 #define V7_NO_FS
 #endif
 
+#define _POSIX_C_SOURCE 200809L
+
 #include <sys/stat.h>
 #include <assert.h>
 #include <ctype.h>
@@ -44,6 +46,7 @@
 typedef unsigned __int64 uint64_t;
 typedef unsigned int uint32_t;
 typedef unsigned char uint8_t;
+char *stpncpy(char *, const char *, size_t);
 #else
 #include <stdint.h>
 #endif

--- a/src/util.c
+++ b/src/util.c
@@ -604,3 +604,10 @@ V7_PRIVATE long _conv_to_int(struct v7 *v7, struct v7_val *arg) {
   if (isnan(tmp) || isinf(tmp)) return 0;
   return tmp;
 }
+
+#ifdef _WIN32
+char *stpncpy(char *dst, const char *src, size_t n) {
+  strncpy(dst, src, n);
+  return dst + strnlen(src, n);
+}
+#endif

--- a/v7.c
+++ b/v7.c
@@ -362,6 +362,8 @@ V7_PRIVATE int is_reserved_word_token(enum v7_tok tok);
 #define V7_NO_FS
 #endif
 
+#define _POSIX_C_SOURCE 200809L
+
 #include <sys/stat.h>
 #include <assert.h>
 #include <ctype.h>
@@ -389,6 +391,7 @@ V7_PRIVATE int is_reserved_word_token(enum v7_tok tok);
 typedef unsigned __int64 uint64_t;
 typedef unsigned int uint32_t;
 typedef unsigned char uint8_t;
+char *stpncpy(char *, const char *, size_t);
 #else
 #include <stdint.h>
 #endif
@@ -988,6 +991,8 @@ V7_PRIVATE struct v7_value *v7_array_length(struct v7 *v7, struct v7_value *);
 #define V7_NO_FS
 #endif
 
+#define _POSIX_C_SOURCE 200809L
+
 #include <sys/stat.h>
 #include <assert.h>
 #include <ctype.h>
@@ -1015,6 +1020,7 @@ V7_PRIVATE struct v7_value *v7_array_length(struct v7 *v7, struct v7_value *);
 typedef unsigned __int64 uint64_t;
 typedef unsigned int uint32_t;
 typedef unsigned char uint8_t;
+char *stpncpy(char *, const char *, size_t);
 #else
 #include <stdint.h>
 #endif
@@ -2371,6 +2377,13 @@ V7_PRIVATE long _conv_to_int(struct v7 *v7, struct v7_val *arg) {
   if (isnan(tmp) || isinf(tmp)) return 0;
   return tmp;
 }
+
+#ifdef _WIN32
+char *stpncpy(char *dst, const char *src, size_t n) {
+  strncpy(dst, src, n);
+  return dst + strnlen(src, n);
+}
+#endif
 /*
  * Copyright (c) 2014 Cesanta Software Limited
  * All rights reserved


### PR DESCRIPTION
Required in order to use `stpncpy` on linux.
Added shim for windows.

Probably the shim should be enabled in other platforms
as well, such as FreeBSD < 8, OSX < 10.7
