### PR TITLE
Optimize `cmp` function.

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -269,31 +269,15 @@ V7_PRIVATE struct v7_val v7_str_to_val(const char *buf) {
 }
 
 V7_PRIVATE int cmp(const struct v7_val *a, const struct v7_val *b) {
-  int res;
   double an, bn;
   const struct v7_string *as, *bs;
-  struct v7_val ta = MKOBJ(0), tb = MKOBJ(0);
 
   if (a == NULL || b == NULL) return 1;
+  if (a->type != b->type) return 1;
+
   if ((a->type == V7_TYPE_UNDEF || a->type == V7_TYPE_NULL) &&
       (b->type == V7_TYPE_UNDEF || b->type == V7_TYPE_NULL))
     return 0;
-
-  if (is_num(a) && is_num(b)) {
-    v7_init_num(&ta, a->v.num);
-    v7_init_num(&tb, b->v.num);
-    a = &ta;
-    b = &tb;
-  }
-
-  if (is_string(a) && is_string(b)) {
-    v7_init_str(&ta, a->v.str.buf, a->v.str.len, 0);
-    v7_init_str(&tb, b->v.str.buf, b->v.str.len, 0);
-    a = &ta;
-    b = &tb;
-  }
-
-  if (a->type != b->type) return 1;
 
   an = a->v.num, bn = b->v.num;
   as = &a->v.str, bs = &b->v.str;
@@ -304,9 +288,7 @@ V7_PRIVATE int cmp(const struct v7_val *a, const struct v7_val *b) {
     case V7_TYPE_BOOL:
       return an != bn;
     case V7_TYPE_STR:
-      res = memcmp(as->buf, bs->buf, as->len < bs->len ? as->len : bs->len);
-      return res != 0 ? res : (int) as->len - (int) bs->len;
-      return as->len != bs->len || memcmp(as->buf, bs->buf, as->len) != 0;
+      return (as->len != bs->len) || (memcmp(as->buf, bs->buf, as->len) != 0);
     default:
       return (int) (a - b);
   }

--- a/v7.c
+++ b/v7.c
@@ -1592,28 +1592,13 @@ V7_PRIVATE int cmp(const struct v7_val *a, const struct v7_val *b) {
   int res;
   double an, bn;
   const struct v7_string *as, *bs;
-  struct v7_val ta = MKOBJ(0), tb = MKOBJ(0);
 
   if (a == NULL || b == NULL) return 1;
+  if (a->type != b->type) return 1;
+
   if ((a->type == V7_TYPE_UNDEF || a->type == V7_TYPE_NULL) &&
       (b->type == V7_TYPE_UNDEF || b->type == V7_TYPE_NULL))
     return 0;
-
-  if (is_num(a) && is_num(b)) {
-    v7_init_num(&ta, a->v.num);
-    v7_init_num(&tb, b->v.num);
-    a = &ta;
-    b = &tb;
-  }
-
-  if (is_string(a) && is_string(b)) {
-    v7_init_str(&ta, a->v.str.buf, a->v.str.len, 0);
-    v7_init_str(&tb, b->v.str.buf, b->v.str.len, 0);
-    a = &ta;
-    b = &tb;
-  }
-
-  if (a->type != b->type) return 1;
 
   an = a->v.num, bn = b->v.num;
   as = &a->v.str, bs = &b->v.str;
@@ -1624,9 +1609,7 @@ V7_PRIVATE int cmp(const struct v7_val *a, const struct v7_val *b) {
     case V7_TYPE_BOOL:
       return an != bn;
     case V7_TYPE_STR:
-      res = memcmp(as->buf, bs->buf, as->len < bs->len ? as->len : bs->len);
-      return res != 0 ? res : (int) as->len - (int) bs->len;
-      return as->len != bs->len || memcmp(as->buf, bs->buf, as->len) != 0;
+      return (as->len != bs->len) || (memcmp(as->buf, bs->buf, as->len) != 0);
     default:
       return (int) (a - b);
   }

--- a/v7.c
+++ b/v7.c
@@ -1589,7 +1589,6 @@ V7_PRIVATE struct v7_val v7_str_to_val(const char *buf) {
 }
 
 V7_PRIVATE int cmp(const struct v7_val *a, const struct v7_val *b) {
-  int res;
   double an, bn;
   const struct v7_string *as, *bs;
 


### PR DESCRIPTION
Before:
% time ./v7 fib.js
[0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987, 1597,
2584, 4181, 6765, 10946, 17711, 28657, 46368, 75025, 121393, 196418,
317811, 514229, 832040]
7049123
./v7 fib.js  71,47s user 0,13s system 99% cpu 1:11,85 total

After:
% time ./v7 fib.js
[0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987, 1597,
2584, 4181, 6765, 10946, 17711, 28657, 46368, 75025, 121393, 196418,
317811, 514229, 832040]
7049123
./v7 fib.js  42,39s user 0,08s system 99% cpu 42,573 total

Compiled with gcc 4.8 using

% gcc -O3 -g -DNDEBUG -DV7_EXE v7.c -o v7 -lm