### PR TITLE
Traverse prototype chain

### DIFF
--- a/src/vm.h
+++ b/src/vm.h
@@ -97,6 +97,7 @@ struct v7_function {
    * objects can be managed by the GC.
    */
   struct v7_property *properties;
+  struct v7_object *scope;    /* lexical scope of the closure */
   struct ast *ast;            /* AST, used as a byte code for execution */
   unsigned int ast_off;       /* Position of the function node in the AST */
 };
@@ -130,6 +131,8 @@ int val_to_boolean(val_t);
 double val_to_double(val_t);
 v7_cfunction_t val_to_cfunction(val_t);
 const char *val_to_string(struct v7 *, val_t *, size_t *);
+
+V7_PRIVATE val_t v_get_prototype(val_t);
 
 /* TODO(lsm): NaN payload location depends on endianness, make crossplatform */
 #define GET_VAL_NAN_PAYLOAD(v) ((char *) &(v))

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,7 @@
 PROG = unit_test
 SRC_DIR=../src
 WARNS = -W -Wall -Wno-comment -Wno-variadic-macros
-V7_FLAGS = -I$(SRC_DIR) -I. -DV7_EXPOSE_PRIVATE
+V7_FLAGS = -I$(SRC_DIR) -I. -DV7_EXPOSE_PRIVATE # -DECMA_FORK
 CFLAGS = $(WARNS) -g -O0 $(V7_FLAGS) $(CFLAGS_EXTRA)
 LDFLAGS = -lm
 AMALGAMATED_SOURCES = ../v7.c

--- a/tests/test.mk
+++ b/tests/test.mk
@@ -70,7 +70,7 @@ SOURCES_gcov=$(addprefix $(SRC_DIR)/, $(SOURCES))
 SOURCES_asan=$(addprefix $(SRC_DIR)/, $(SOURCES))
 
 CC_asan=$(CLANG)
-CFLAGS_asan=-fsanitize=address -fcolor-diagnostics -std=c99 -DNO_DNS_TEST -UNS_ENABLE_SSL
+CFLAGS_asan=-fsanitize=address -fcolor-diagnostics -std=c99
 CMD_asan=ASAN_SYMBOLIZER_PATH=/usr/local/bin/llvm-symbolizer-3.5 ASAN_OPTIONS=allocator_may_return_null=1,symbolize=1 $(CMD)
 
 CMD_valgrind=valgrind


### PR DESCRIPTION
Implement function invokation scope as chain
of frames chained via the __proto__ field, so that
variables from outer lexical scopes are looked up
via the same mechanism as object property lookup.

Fix prototype name comparison.

Allow ECMA test sandboxing so that unit test doesn't crash
when we enable a codepath that triggers an interpreter bug.
(disabled by default, enable in tests/Makefile)