### PR TITLE
Evaluate empty input to V7_NULL

### DIFF
--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -610,7 +610,7 @@ static val_t i_eval_stmt(struct v7 *, struct ast *, ast_off_t *, val_t, enum i_b
 
 static val_t i_eval_stmts(struct v7 *v7, struct ast *a, ast_off_t *pos,
                           ast_off_t end, val_t scope, enum i_break *brk) {
-  val_t res;
+  val_t res = V7_NULL;
   while (*pos < end && !*brk) {
     res = i_eval_stmt(v7, a, pos, scope, brk);
   }
@@ -620,7 +620,7 @@ static val_t i_eval_stmts(struct v7 *v7, struct ast *a, ast_off_t *pos,
 static val_t i_eval_stmt(struct v7 *v7, struct ast *a, ast_off_t *pos,
                          val_t scope, enum i_break *brk) {
   enum ast_tag tag = ast_fetch_tag(a, pos);
-  val_t res;
+  val_t res = V7_NULL;
   ast_off_t end, cond, iter_end, loop, iter, finally, catch;
 
   switch (tag) {

--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -98,7 +98,7 @@ static const char *test_is_true(void) {
   ASSERT(test_if_expr(v7, "-Infinity", 1));
 #endif
   ASSERT(test_if_expr(v7, "[]", 1));
-  ASSERT(test_if_expr(v7, "{}", 1));
+  ASSERT(test_if_expr(v7, "var x = {}", 1));
   ASSERT(test_if_expr(v7, "[[]]", 1));
   ASSERT(test_if_expr(v7, "[0]", 1));
   ASSERT(test_if_expr(v7, "[1]", 1));
@@ -1037,6 +1037,8 @@ static const char *test_interpreter(void) {
 
   ASSERT((v = v7_exec(v7, "o={};a=[o];o.a=a;a")) != V7_UNDEFINED);
   ASSERT(check_value(v7, v, "[{\"a\":[Circular]}]"));
+
+  ASSERT((v = v7_exec(v7, "")) == V7_NULL);
 #if 0
   ASSERT((v = v7_exec(v7, "x=0;a=1;o={a:2};with(o){x=a};x")) != V7_UNDEFINED);
   ASSERT(check_value(v7, v, "2"));

--- a/v7.c
+++ b/v7.c
@@ -5919,7 +5919,7 @@ static val_t i_eval_stmt(struct v7 *, struct ast *, ast_off_t *, val_t, enum i_b
 
 static val_t i_eval_stmts(struct v7 *v7, struct ast *a, ast_off_t *pos,
                           ast_off_t end, val_t scope, enum i_break *brk) {
-  val_t res;
+  val_t res = V7_NULL;
   while (*pos < end && !*brk) {
     res = i_eval_stmt(v7, a, pos, scope, brk);
   }
@@ -5929,7 +5929,7 @@ static val_t i_eval_stmts(struct v7 *v7, struct ast *a, ast_off_t *pos,
 static val_t i_eval_stmt(struct v7 *v7, struct ast *a, ast_off_t *pos,
                          val_t scope, enum i_break *brk) {
   enum ast_tag tag = ast_fetch_tag(a, pos);
-  val_t res;
+  val_t res = V7_NULL;
   ast_off_t end, cond, iter_end, loop, iter, finally, catch;
 
   switch (tag) {


### PR DESCRIPTION
Currently `./v7 -e ''` evaluates to some random number.