### PR TITLE
Split v7_create_value to type-specific functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ V7_FLAGS = -I./src -I.
 CFLAGS = $(WARNS) -g -O0 -lm $(PROF) $(V7_FLAGS) $(CFLAGS_EXTRA)
 
 SRC_DIR=src
-TOP_SOURCES=$(addprefix $(SRC_DIR)/, $(SOURCES))
+TOP_SOURCES=$(realpath $(addprefix $(SRC_DIR)/, $(SOURCES)))
 TOP_HEADERS=$(addprefix $(SRC_DIR)/, $(HEADERS))
 
 include src/sources.mk

--- a/src/ast.c
+++ b/src/ast.c
@@ -449,8 +449,9 @@ V7_PRIVATE ast_off_t ast_modify_skip(struct ast *a, ast_off_t start,
 
 V7_PRIVATE ast_off_t ast_get_skip(struct ast *a, ast_off_t pos,
                                   enum ast_which_skip skip) {
+  uint8_t *p;
   assert(pos + skip * sizeof(ast_skip_t) < a->mbuf.len);
-  uint8_t * p = (uint8_t *) a->mbuf.buf + pos + skip * sizeof(ast_skip_t);
+  p = (uint8_t *) a->mbuf.buf + pos + skip * sizeof(ast_skip_t);
   return pos + (p[1] | p[0] << 8);
 }
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -150,8 +150,8 @@ enum v7_type {
 
 struct v7 {
   val_t global_object;
-  struct v7_object *object_prototype;
-  struct v7_object *array_prototype;
+  val_t object_prototype;
+  val_t array_prototype;
   val_t this_object;
 
   /*

--- a/src/vm.h
+++ b/src/vm.h
@@ -137,34 +137,9 @@ V7_PRIVATE val_t v_get_prototype(val_t);
 /* TODO(lsm): NaN payload location depends on endianness, make crossplatform */
 #define GET_VAL_NAN_PAYLOAD(v) ((char *) &(v))
 
-/*
- * Create a value with the given type.
- * Last arguments to a function depend on `type`:
- * - For `V7_TYPE_UNDEFINED` and `V7_TYPE_NULL` - no argument
- * - For `V7_TYPE_NUMBER`, `v7_num_t` argument
- * - For `V7_TYPE_BOOLEAN`, `int` argument
- * - For `V7_TYPE_STRING`, `char *` followed by `v7_strlen_t` argument
- * - For everything else, `val_t` argument. Value is not copied.
- * Return NULL on failure.
- */
-val_t v7_create_value(struct v7 *, enum v7_type, ...);
-val_t v7_va_create_value(struct v7 *, enum v7_type, va_list);
-
-int v7_stringify_value(struct v7 *, val_t, char *, size_t);
+V7_PRIVATE v7_val_t v7_create_function(struct v7 *v7);
+V7_PRIVATE int v7_stringify_value(struct v7 *, val_t, char *, size_t);
 V7_PRIVATE struct v7_property *v7_create_property(struct v7 *);
-
-int v7_set_property_value(struct v7 *, val_t obj,
-                          const char *name, size_t len,
-                          unsigned int attributes, val_t val);
-
-/*
- * Set a property for an object.
- * `obj` must be a object value. Last arguments depend on `type` (see above).
- * Return 0 on success, -1 on error.
- */
-int v7_set_property(struct v7 *, val_t obj,
-                    const char *name, size_t len,
-                    unsigned int attributes, enum v7_type, ...);
 
 /* If `len` is -1/MAXUINT/~0, then `name` must be 0-terminated */
 V7_PRIVATE struct v7_property *v7_get_property(val_t obj,

--- a/tests/test.mk
+++ b/tests/test.mk
@@ -25,6 +25,7 @@
 # - test_asan: run with AddressSanitizer
 # - test_valgrind: run with valgrind
 
+SRC = $(realpath $(PROG).c)
 CLANG:=clang
 
 # OSX clang doesn't build ASAN. Use brew:
@@ -102,9 +103,9 @@ compile:
 	@make -j8 $(foreach p,$(DIALECTS),$(PROG)-$(p)) CFLAGS_EXTRA=-fsyntax-only LDFLAGS=
 
 # HACK: cannot have two underscores
-$(PROG)-%: Makefile $(PROG).c $(or $(SOURCES_$*), $(AMALGAMATED_SOURCES))
+$(PROG)-%: Makefile $(SRC) $(or $(SOURCES_$*), $(AMALGAMATED_SOURCES))
 	@echo -e "CC\t$(PROG)_$*"
-	$(or $(CC_$*), $(CC)) $(CFLAGS_$*) $(PROG).c $(or $(SOURCES_$*), $(AMALGAMATED_SOURCES)) -o $(PROG)_$* $(CFLAGS) $(LDFLAGS)
+	$(or $(CC_$*), $(CC)) $(CFLAGS_$*) $(SRC) $(or $(SOURCES_$*), $(AMALGAMATED_SOURCES)) -o $(PROG)_$* $(CFLAGS) $(LDFLAGS)
 
 $(ALL_TESTS): test_%: Makefile $(PROG)-%
 	@echo -e "RUN\t$(PROG)_$* $(TEST_FILTER)"
@@ -112,7 +113,7 @@ $(ALL_TESTS): test_%: Makefile $(PROG)-%
 
 coverage: Makefile clean_coverage test_gcov
 	@echo -e "RUN\tGCOV"
-	@gcov -p $(PROG).c $(notdir $(SOURCES)) >/dev/null
+	@gcov -p $(SRC) $(notdir $(SOURCES)) >/dev/null
 
 test_leaks: Makefile
 	$(MAKE) test_valgrind CMD_valgrind="$(CMD_valgrind) --leak-check=full"

--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -137,8 +137,8 @@ static const char *test_native_functions(void) {
   val_t v;
   struct v7 *v7 = v7_create();
 
-  ASSERT(v7_set_property_value(v7, v7_get_global_object(v7), "adder", 5, 0,
-         v7_create_value(v7, V7_TYPE_CFUNCTION_OBJECT, adder)) == 0);
+  ASSERT(v7_set_property(v7, v7_get_global_object(v7), "adder", 5, 0,
+         v7_create_cfunction(adder)) == 0);
   ASSERT((v = v7_exec(v7, "adder(1, 2, 3 + 4);")) != V7_UNDEFINED);
   ASSERT(check_value(v7, v, "10"));
   v7_destroy(v7);
@@ -301,68 +301,68 @@ static const char *test_runtime(void) {
   struct v7_property *p;
   size_t n;
 
-  v = v7_create_value(v7, V7_TYPE_NULL);
+  v = v7_create_null();
   ASSERT(v == V7_NULL);
 
-  v = v7_create_value(v7, V7_TYPE_UNDEFINED);
+  v = v7_create_undefined();
   ASSERT(v == V7_UNDEFINED);
 
-  v = v7_create_value(v7, V7_TYPE_NUMBER, 1.0);
+  v = v7_create_number(1.0);
   ASSERT(val_type(v7, v) == V7_TYPE_NUMBER);
   ASSERT(val_to_double(v) == 1.0);
   ASSERT(check_value(v7, v, "1"));
 
-  v = v7_create_value(v7, V7_TYPE_NUMBER, 1.5);
+  v = v7_create_number(1.5);
   ASSERT(val_to_double(v) == 1.5);
   ASSERT(check_value(v7, v, "1.5"));
 
-  v = v7_create_value(v7, V7_TYPE_BOOLEAN, 1);
+  v = v7_create_boolean(1);
   ASSERT(val_type(v7, v) == V7_TYPE_BOOLEAN);
   ASSERT(val_to_boolean(v) == 1);
   ASSERT(check_value(v7, v, "true"));
 
-  v = v7_create_value(v7, V7_TYPE_BOOLEAN, 0);
+  v = v7_create_boolean(0);
   ASSERT(check_value(v7, v, "false"));
 
-  v = v7_create_value(v7, V7_TYPE_STRING, "foo", 3);
+  v = v7_create_string(v7, "foo", 3, 1);
   ASSERT(val_type(v7, v) == V7_TYPE_STRING);
   val_to_string(v7, &v, &n);
   ASSERT(n == 3);
   ASSERT(check_value(v7, v, "\"foo\""));
 
-  v = v7_create_value(v7, V7_TYPE_GENERIC_OBJECT);
+  v = v7_create_object(v7);
   ASSERT(val_type(v7, v) == V7_TYPE_GENERIC_OBJECT);
   ASSERT(val_to_object(v) != NULL);
 
-  ASSERT(v7_set_property(v7, v, "foo", -1, 0, V7_TYPE_NULL) == 0);
+  ASSERT(v7_set_property(v7, v, "foo", -1, 0, v7_create_null()) == 0);
   ASSERT((p = v7_get_property(v, "foo", -1)) != NULL);
   ASSERT(p->attributes == 0);
   ASSERT(p->value == V7_NULL);
   ASSERT(check_value(v7, p->value, "null"));
 
-  ASSERT(v7_set_property(v7, v, "foo", -1, 0, V7_TYPE_UNDEFINED) == 0);
+  ASSERT(v7_set_property(v7, v, "foo", -1, 0, v7_create_undefined()) == 0);
   ASSERT((p = v7_get_property(v, "foo", -1)) != NULL);
   ASSERT(check_value(v7, p->value, "undefined"));
 
-  ASSERT(v7_set_property(v7, v, "foo", -1, 0, V7_TYPE_STRING,
-         "bar", (size_t) 3) == 0);
+  ASSERT(v7_set_property(v7, v, "foo", -1, 0,
+         v7_create_string(v7, "bar", 3, 1)) == 0);
   ASSERT((p = v7_get_property(v, "foo", -1)) != NULL);
   ASSERT(check_value(v7, p->value, "\"bar\""));
 
-  ASSERT(v7_set_property(v7, v, "foo", -1, 0, V7_TYPE_STRING,
-         "zar", (size_t) 3, 1) == 0);
+  ASSERT(v7_set_property(v7, v, "foo", -1, 0,
+         v7_create_string(v7, "zar", 3, 1)) == 0);
   ASSERT((p = v7_get_property(v, "foo", -1)) != NULL);
   ASSERT(check_value(v7, p->value, "\"zar\""));
 
   ASSERT(v7_del_property(v, "foo", ~0) == 0);
   ASSERT(val_to_object(v)->properties == NULL);
   ASSERT(v7_del_property(v, "foo", -1) == -1);
-  ASSERT(v7_set_property(v7, v, "foo", -1, 0, V7_TYPE_STRING,
-         "bar", (size_t) 3, 1) == 0);
-  ASSERT(v7_set_property(v7, v, "bar", -1, 0, V7_TYPE_STRING,
-         "foo", (size_t) 3, 1) == 0);
-  ASSERT(v7_set_property(v7, v, "aba", -1, 0, V7_TYPE_STRING,
-         "bab", (size_t) 3, 1) == 0);
+  ASSERT(v7_set_property(v7, v, "foo", -1, 0,
+         v7_create_string(v7, "bar", 3, 1)) == 0);
+  ASSERT(v7_set_property(v7, v, "bar", -1, 0,
+         v7_create_string(v7, "foo", 3, 1)) == 0);
+  ASSERT(v7_set_property(v7, v, "aba", -1, 0,
+         v7_create_string(v7, "bab", 3, 1)) == 0);
   ASSERT(v7_del_property(v, "foo", -1) == 0);
   ASSERT((p = v7_get_property(v, "foo", -1)) == NULL);
   ASSERT(v7_del_property(v, "aba", -1) == 0);
@@ -370,13 +370,13 @@ static const char *test_runtime(void) {
   ASSERT(v7_del_property(v, "bar", -1) == 0);
   ASSERT((p = v7_get_property(v, "bar", -1)) == NULL);
 
-  v = v7_create_value(v7, V7_TYPE_GENERIC_OBJECT);
-  ASSERT(v7_set_property(v7, v, "foo", -1, 0, V7_TYPE_NUMBER, 1.0) == 0);
+  v = v7_create_object(v7);
+  ASSERT(v7_set_property(v7, v, "foo", -1, 0, v7_create_number(1.0)) == 0);
   ASSERT((p = v7_get_property(v, "foo", -1)) != NULL);
   ASSERT((p = v7_get_property(v, "f", -1)) == NULL);
 
-  v = v7_create_value(v7, V7_TYPE_GENERIC_OBJECT);
-  ASSERT(v7_set_property_value(v7, v, "foo", -1, 0, v) == 0);
+  v = v7_create_object(v7);
+  ASSERT(v7_set_property(v7, v, "foo", -1, 0, v) == 0);
   ASSERT(check_value(v7, v, "{\"foo\":[Circular]}"));
 
   v7_destroy(v7);
@@ -779,7 +779,7 @@ static const char *test_interpreter(void) {
   struct v7 *v7 = v7_create();
   val_t v;
 
-  v7_set_property(v7, v7->global_object, "x", -1, 0, V7_TYPE_NUMBER, 42.0);
+  v7_set_property(v7, v7->global_object, "x", -1, 0, v7_create_number(42.0));
 
   ASSERT((v = v7_exec(v7, "1%2/2")) != V7_UNDEFINED);
   ASSERT(check_value(v7, v, "0.5"));

--- a/v7.h
+++ b/v7.h
@@ -23,6 +23,8 @@
 extern "C" {
 #endif /* __cplusplus */
 
+#include <stddef.h>   /* For size_t */
+
 #define V7_VERSION "1.0"
 
 struct v7;     /* Opaque structure. V7 engine handler. */
@@ -33,16 +35,29 @@ struct v7_val; /* Opaque structure. Holds V7 value, which has v7_type type. */
 #include <inttypes.h>
 typedef uint64_t v7_val_t;
 
+typedef v7_val_t (*v7_cfunction_t)(struct v7 *, v7_val_t args);
+
 struct v7 *v7_create(void);     /* Creates and initializes V7 engine */
 void v7_destroy(struct v7 *);   /* Cleanes up and deallocates V7 engine */
-typedef v7_val_t (*v7_cfunction_t)(struct v7 *, v7_val_t args);
-void v7_array_append(struct v7 *, v7_val_t arr, v7_val_t v);
-v7_val_t v7_array_at(struct v7 *, v7_val_t arr, long index);
-v7_val_t v7_get_global_object(struct v7 *);
 v7_val_t v7_exec(struct v7 *, const char *str);       /* Execute string */
 v7_val_t v7_exec_file(struct v7 *, const char *path); /* Execute file */
-char *v7_to_json(struct v7 *, v7_val_t, char *, int);
+
+v7_val_t v7_create_object(struct v7 *v7);
+v7_val_t v7_create_array(struct v7 *v7);
+v7_val_t v7_create_cfunction(v7_cfunction_t func);
+v7_val_t v7_create_number(double num);
+v7_val_t v7_create_boolean(int is_true);
+v7_val_t v7_create_null(void);
+v7_val_t v7_create_undefined(void);
+v7_val_t v7_create_string(struct v7 *v7, const char *, size_t, int);
+
+v7_val_t v7_get_global_object(struct v7 *);
+int v7_set_property(struct v7 *, v7_val_t obj, const char *name, size_t len,
+                    unsigned int attributes, v7_val_t val);
+char *v7_to_json(struct v7 *, v7_val_t, char *, size_t);
 int v7_is_true(struct v7 *v7, v7_val_t v);
+void v7_array_append(struct v7 *, v7_val_t arr, v7_val_t v);
+v7_val_t v7_array_at(struct v7 *, v7_val_t arr, long index);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Added $(realpath) to makefiles to let IDE know the exact file location to jump to compilation errors.
Fixed warning in interpreter.c
Exported creation functions to v7.h