### PR TITLE
Fix `v7_exec` API

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -7,14 +7,15 @@
 
 
 V7_PRIVATE void init_error(struct v7 *v7) {
-  v7_exec(v7, "function Error(m) {this.message = m}");
-  v7_exec(v7, "function TypeError(m) {this.message = m};"
+  val_t v;
+  v7_exec(v7, &v, "function Error(m) {this.message = m}");
+  v7_exec(v7, &v, "function TypeError(m) {this.message = m};"
             "TypeError.prototype = Object.create(Error.prototype)");
-  v7_exec(v7, "function SyntaxError(m) {this.message = m};"
+  v7_exec(v7, &v, "function SyntaxError(m) {this.message = m};"
             "SyntaxError.prototype = Object.create(Error.prototype)");
-  v7_exec(v7, "function ReferenceError(m) {this.message = m};"
+  v7_exec(v7, &v, "function ReferenceError(m) {this.message = m};"
             "ReferenceError.prototype = Object.create(Error.prototype)");
-  v7_exec(v7, "function ImplementationError(m) {this.message = m};"
+  v7_exec(v7, &v, "function ImplementationError(m) {this.message = m};"
             "ReferenceError.prototype = Object.create(Error.prototype)");
 
   v7->error_prototype = v7_property_value(v7_get_property(

--- a/src/internal.h
+++ b/src/internal.h
@@ -202,6 +202,7 @@ struct v7 {
                       __func__, __LINE__, #COND);                       \
   } while (0)
 
+V7_PRIVATE void throw_value(struct v7 *, val_t);
 V7_PRIVATE void throw_exception(struct v7 *, const char *, const char *, ...);
 V7_PRIVATE size_t unescape(const char *s, size_t len, char *to);
 

--- a/src/main.c
+++ b/src/main.c
@@ -67,7 +67,7 @@ int main(int argc, char *argv[]) {
     if (strcmp(argv[i], "-e") == 0 && i + 1 < argc) {
       if (show_ast) {
         dump_ast(v7, argv[i + 1], binary_ast);
-      } else if (v7_is_error(v7, res = v7_exec(v7, argv[i + 1]))) {
+      } else if (v7_exec(v7, &res, argv[i + 1]) != V7_OK) {
         print_error(v7, argv[i + 1], res);
         res = V7_UNDEFINED;
       }
@@ -97,7 +97,7 @@ int main(int argc, char *argv[]) {
         dump_ast(v7, source_code, binary_ast);
         free(source_code);
       }
-    } else if (v7_is_error(v7, res = v7_exec_file(v7, argv[i]))) {
+    } else if (v7_exec_file(v7, &res, argv[i]) != V7_OK) {
       print_error(v7, argv[i], res);
       res = V7_UNDEFINED;
     }

--- a/src/object.c
+++ b/src/object.c
@@ -179,9 +179,9 @@ V7_PRIVATE enum v7_err Obj_keys(struct v7_c_func_arg *cfa) {
 
 #endif
 V7_PRIVATE void init_object(struct v7 *v7) {
-  val_t object;
+  val_t object, v;
   /* TODO(mkm): initialize global object without requiring a parser */
-  v7_exec(v7, "function Object() {}");
+  v7_exec(v7, &v, "function Object() {}");
 
   object = v7_property_value(v7_get_property(v7->global_object, "Object", 6));
   v7_set_property(v7, object, "prototype", 9, 0, v7->object_prototype);

--- a/src/parser.c
+++ b/src/parser.c
@@ -68,7 +68,7 @@ static enum v7_err parse_ident(struct v7 *v7, struct ast *a) {
     next_tok(v7);
     return V7_OK;
   }
-  return V7_ERROR;
+  return V7_SYNTAX_ERROR;
 }
 
 static enum v7_err parse_ident_allow_reserved_words(struct v7 *v7,
@@ -115,7 +115,7 @@ static enum v7_err parse_prop(struct v7 *v7, struct ast *a) {
     } else if (v7->cur_tok == TOK_STRING_LITERAL) {
       ast_add_inlined_node(a, AST_PROP, v7->tok + 1, v7->tok_len - 2);
     } else {
-      return V7_ERROR;
+      return V7_SYNTAX_ERROR;
     }
     next_tok(v7);
     EXPECT(TOK_COLON);
@@ -245,7 +245,7 @@ static enum v7_err parse_member(struct v7 *v7, struct ast *a, ast_off_t pos) {
         ast_insert_inlined_node(a, pos, AST_MEMBER, v7->tok, v7->tok_len);
         next_tok(v7);
       } else {
-        return V7_ERROR;
+        return V7_SYNTAX_ERROR;
       }
       break;
     case TOK_OPEN_BRACKET:
@@ -456,7 +456,7 @@ static enum v7_err end_of_statement(struct v7 *v7) {
       v7->after_newline) {
     return V7_OK;
   }
-  return V7_ERROR;
+  return V7_SYNTAX_ERROR;
 }
 
 static enum v7_err parse_var(struct v7 *v7, struct ast *a) {
@@ -607,7 +607,7 @@ static enum v7_err parse_switch(struct v7 *v7, struct ast *a) {
         ast_set_skip(a, case_start, AST_END_SKIP);
         break;
       default:
-        return V7_ERROR;
+        return V7_SYNTAX_ERROR;
     }
   }
   EXPECT(TOK_CLOSE_CURLY);
@@ -733,9 +733,9 @@ static enum v7_err parse_funcdecl(struct v7 *v7, struct ast *a,
   ast_off_t outer_last_var_node = v7->last_var_node;
   v7->last_var_node = start;
   ast_modify_skip(a, start, start, AST_FUNC_FIRST_VAR_SKIP);
-  if (parse_ident(v7, a) == V7_ERROR) {
+  if (parse_ident(v7, a) == V7_SYNTAX_ERROR) {
     if (require_named) {
-      return V7_ERROR;
+      return V7_SYNTAX_ERROR;
     }
     ast_add_node(a, AST_NOP);
   }

--- a/src/parser.h
+++ b/src/parser.h
@@ -21,7 +21,6 @@ struct v7_pstate {
   int inhibit_in;   /* True while `in` expressions are inhibited */
 };
 
-enum v7_err { V7_OK, V7_ERROR, V7_SYNTAX_ERROR };
 V7_PRIVATE enum v7_err parse(struct v7 *, struct ast *, const char*, int);
 
 #if defined(__cplusplus)

--- a/src/vm.c
+++ b/src/vm.c
@@ -736,7 +736,9 @@ static val_t Std_eval(struct v7 *v7, val_t t, val_t args) {
     if (p[0] == '"') {
       p[0] = p[strlen(p) - 1] = ' ';
     }
-    res = v7_exec(v7, p);
+    if (v7_exec(v7, &res, p) == V7_SYNTAX_ERROR) {
+      throw_value(v7, res);
+    }
     if (p != buf) {
       free(p);
     }

--- a/v7.h
+++ b/v7.h
@@ -27,6 +27,12 @@ extern "C" {
 
 #define V7_VERSION "1.0"
 
+enum v7_err {
+  V7_OK,
+  V7_SYNTAX_ERROR,
+  V7_EXEC_EXCEPTION
+};
+
 struct v7;     /* Opaque structure. V7 engine handler. */
 struct v7_val; /* Opaque structure. Holds V7 value, which has v7_type type. */
 
@@ -39,9 +45,12 @@ typedef v7_val_t (*v7_cfunction_t)(struct v7 *, v7_val_t, v7_val_t);
 
 struct v7 *v7_create(void);     /* Creates and initializes V7 engine */
 void v7_destroy(struct v7 *);   /* Cleanes up and deallocates V7 engine */
-v7_val_t v7_exec(struct v7 *, const char *str);       /* Execute string */
-v7_val_t v7_exec_file(struct v7 *, const char *path); /* Execute file */
-v7_val_t v7_exec_with(struct v7 *, const char *, v7_val_t); /* Execute string */
+enum v7_err v7_exec(struct v7 *, v7_val_t *,
+                    const char *str); /* Execute string */
+enum v7_err v7_exec_file(struct v7 *, v7_val_t *,
+                    const char *path); /* Execute file */
+enum v7_err v7_exec_with(struct v7 *, v7_val_t *,
+                         const char *str, v7_val_t); /* Execute string with */
 
 v7_val_t v7_create_object(struct v7 *v7);
 v7_val_t v7_create_array(struct v7 *v7);


### PR DESCRIPTION
Now values and execution status are separate, allowing
both undefined values to be returned and exceptions not
inheriting from `Error` to be thrown and recognized as
such.