### PR TITLE
Implement {String,Array}.prototype.length

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -21,17 +21,13 @@ V7_PRIVATE val_t Array_push(struct v7 *v7, val_t this_obj, val_t args) {
   return v;
 }
 
-#if 0
-V7_PRIVATE void Arr_length(struct v7_val *this_obj, struct v7_val *arg,
-                           struct v7_val *result) {
-  struct v7_prop *p;
-  if (NULL == result || arg) return;
-  v7_init_num(result, 0.0);
-  for (p = this_obj->v.array; p != NULL; p = p->next) {
-    result->v.num += 1.0;
-  }
+static val_t Arr_length(struct v7 *v7, val_t this_obj, val_t args) {
+  (void) args;
+  assert(val_type(v7, this_obj) == V7_TYPE_ARRAY_OBJECT);
+  return v7_create_number(v7_array_length(v7, this_obj));
 }
 
+#if 0
 V7_PRIVATE int cmp_prop(const void *pa, const void *pb) {
   const struct v7_prop *p1 = *(struct v7_prop **) pa;
   const struct v7_prop *p2 = *(struct v7_prop **) pb;
@@ -67,4 +63,6 @@ V7_PRIVATE void init_array(struct v7 *v7) {
                   v7_create_cfunction(Array_ctor));
   v7_set_property(v7, v7->array_prototype, "push", 4, 0,
                   v7_create_cfunction(Array_push));
+  v7_set_property(v7, v7->array_prototype, "length", 6, V7_PROPERTY_GETTER,
+                  v7_create_cfunction(Arr_length));
 }

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -378,11 +378,6 @@ static val_t i_eval_expr(struct v7 *v7, struct ast *a, ast_off_t *pos,
       name = ast_get_inlined_data(a, *pos, &name_len);
       ast_move_to_children(a, pos);
       v1 = i_eval_expr(v7, a, pos, scope);
-      if (v7_is_string(v1)) {
-        v1 = v7->string_prototype;
-      } else if (v7_is_double(v1)) {
-        v1 = v7->number_prototype;
-      }
       return v7_get(v7, v1, name, name_len);
     case AST_SEQ:
       end = ast_get_skip(a, *pos, AST_END_SKIP);
@@ -1122,7 +1117,7 @@ val_t v7_apply(struct v7 *v7, val_t f, val_t this_object, val_t args) {
   int i;
 
   if (v7_is_cfunction(f)) {
-    return v7_to_cfunction(f)(v7, v7->this_object, args);
+    return v7_to_cfunction(f)(v7, this_object, args);
   }
   if (!v7_is_function(f)) {
     throw_exception(v7, "TypeError", "value is not a function");

--- a/src/vm.c
+++ b/src/vm.c
@@ -465,7 +465,13 @@ struct v7_property *v7_get_property(val_t obj, const char *name, size_t len) {
 }
 
 v7_val_t v7_get(struct v7 *v7, val_t obj, const char *name, size_t name_len) {
-  return v7_property_value(v7, obj, v7_get_property(obj, name, name_len));
+  val_t v = obj;
+  if (v7_is_string(obj)) {
+    v = v7->string_prototype;
+  } else if (v7_is_double(obj)) {
+    v = v7->number_prototype;
+  }
+  return v7_property_value(v7, obj, v7_get_property(v, name, name_len));
 }
 
 static void v7_destroy_property(struct v7_property **p) {

--- a/tests/ecma_report.txt
+++ b/tests/ecma_report.txt
@@ -251,22 +251,22 @@
 250	PASS (tail -c +178139 tests/ecmac.db|head -c 715)
 251	PASS (tail -c +178855 tests/ecmac.db|head -c 699)
 252	PASS (tail -c +179555 tests/ecmac.db|head -c 696)
-253	PASS (tail -c +180252 tests/ecmac.db|head -c 1141)
-254	PASS (tail -c +181394 tests/ecmac.db|head -c 1101)
-255	PASS (tail -c +182496 tests/ecmac.db|head -c 1126)
-256	PASS (tail -c +183623 tests/ecmac.db|head -c 1127)
-257	PASS (tail -c +184751 tests/ecmac.db|head -c 1140)
-258	PASS (tail -c +185892 tests/ecmac.db|head -c 1141)
-259	PASS (tail -c +187034 tests/ecmac.db|head -c 1150)
-260	PASS (tail -c +188185 tests/ecmac.db|head -c 1141)
-261	PASS (tail -c +189327 tests/ecmac.db|head -c 1112)
-262	PASS (tail -c +190440 tests/ecmac.db|head -c 1140)
-263	PASS (tail -c +191581 tests/ecmac.db|head -c 1106)
-264	PASS (tail -c +192688 tests/ecmac.db|head -c 1130)
-265	PASS (tail -c +193819 tests/ecmac.db|head -c 1129)
-266	PASS (tail -c +194949 tests/ecmac.db|head -c 1145)
-267	PASS (tail -c +196095 tests/ecmac.db|head -c 1122)
-268	PASS (tail -c +197218 tests/ecmac.db|head -c 1113)
+253	FAIL (tail -c +180252 tests/ecmac.db|head -c 1141): [{"message":"Test case returned non-true value!"}]
+254	FAIL (tail -c +181394 tests/ecmac.db|head -c 1101): [{"message":"Test case returned non-true value!"}]
+255	FAIL (tail -c +182496 tests/ecmac.db|head -c 1126): [{"message":"Test case returned non-true value!"}]
+256	FAIL (tail -c +183623 tests/ecmac.db|head -c 1127): [{"message":"Test case returned non-true value!"}]
+257	FAIL (tail -c +184751 tests/ecmac.db|head -c 1140): [{"message":"Test case returned non-true value!"}]
+258	FAIL (tail -c +185892 tests/ecmac.db|head -c 1141): [{"message":"Test case returned non-true value!"}]
+259	FAIL (tail -c +187034 tests/ecmac.db|head -c 1150): [{"message":"Test case returned non-true value!"}]
+260	FAIL (tail -c +188185 tests/ecmac.db|head -c 1141): [{"message":"Test case returned non-true value!"}]
+261	FAIL (tail -c +189327 tests/ecmac.db|head -c 1112): [{"message":"Test case returned non-true value!"}]
+262	FAIL (tail -c +190440 tests/ecmac.db|head -c 1140): [{"message":"Test case returned non-true value!"}]
+263	FAIL (tail -c +191581 tests/ecmac.db|head -c 1106): [{"message":"Test case returned non-true value!"}]
+264	FAIL (tail -c +192688 tests/ecmac.db|head -c 1130): [{"message":"Test case returned non-true value!"}]
+265	FAIL (tail -c +193819 tests/ecmac.db|head -c 1129): [{"message":"Test case returned non-true value!"}]
+266	FAIL (tail -c +194949 tests/ecmac.db|head -c 1145): [{"message":"Test case returned non-true value!"}]
+267	FAIL (tail -c +196095 tests/ecmac.db|head -c 1122): [{"message":"Test case returned non-true value!"}]
+268	FAIL (tail -c +197218 tests/ecmac.db|head -c 1113): [{"message":"Test case returned non-true value!"}]
 269	PASS (tail -c +198332 tests/ecmac.db|head -c 1689)
 270	FAIL (tail -c +200022 tests/ecmac.db|head -c 512): [{"message":"Test case returned non-true value!"}]
 271	FAIL (tail -c +200535 tests/ecmac.db|head -c 499): [{"message":"Test case returned non-true value!"}]
@@ -641,8 +641,8 @@
 640	PASS (tail -c +424730 tests/ecmac.db|head -c 572)
 641	FAIL (tail -c +425303 tests/ecmac.db|head -c 555): [{"message":"#1: var str = "rock'n'roll"; str.constructor === String. Actual: undefined"}]
 642	PASS (tail -c +425859 tests/ecmac.db|head -c 702)
-643	FAIL (tail -c +426562 tests/ecmac.db|head -c 510): [{"message":"#1: var __str = "ABCDEFGH"; __str.length === 8. Actual: undefined"}]
-644	FAIL (tail -c +427073 tests/ecmac.db|head -c 503): [{"message":"#1: var __str = ""; __str.length === 0. Actual: "}]
+643	PASS (tail -c +426562 tests/ecmac.db|head -c 510)
+644	PASS (tail -c +427073 tests/ecmac.db|head -c 503)
 645	PASS (tail -c +427577 tests/ecmac.db|head -c 394)
 646	PASS (tail -c +427972 tests/ecmac.db|head -c 8567)
 647	PASS (tail -c +436540 tests/ecmac.db|head -c 16759)
@@ -692,7 +692,7 @@
 691	PASS (tail -c +490976 tests/ecmac.db|head -c 818)
 692	PASS (tail -c +491795 tests/ecmac.db|head -c 848)
 693	PASS (tail -c +492644 tests/ecmac.db|head -c 1027)
-694	FAIL (tail -c +493672 tests/ecmac.db|head -c 1557): [{"message":"#1: var items = new Array( "one", "two", "three" ); var itemsRef = items; items.push( "four" );var itemsRef = items; itemsRef.length !== 4"}]
+694	PASS (tail -c +493672 tests/ecmac.db|head -c 1557)
 695	PASS (tail -c +495230 tests/ecmac.db|head -c 993)
 696	PASS (tail -c +496224 tests/ecmac.db|head -c 993)
 697	FAIL (tail -c +497218 tests/ecmac.db|head -c 1839): [{"message":"#1: typeof(__ref) === "undefined". Actual: object"}]
@@ -1708,7 +1708,7 @@
 1708	PASS (tail -c +1269567 tests/ecmac.db|head -c 753)
 1709	FAIL (tail -c +1270321 tests/ecmac.db|head -c 896): [{"message":"value is not a function"}]
 1710	FAIL (tail -c +1271218 tests/ecmac.db|head -c 1087): [{"message":"value is not a function"}]
-1711	FAIL (tail -c +1272306 tests/ecmac.db|head -c 1110): [{"message":"value is not a function"}]
+1711	PASS (tail -c +1272306 tests/ecmac.db|head -c 1110)
 1712	PASS (tail -c +1273417 tests/ecmac.db|head -c 866)
 1713	PASS (tail -c +1274284 tests/ecmac.db|head -c 821)
 1714	PASS (tail -c +1275106 tests/ecmac.db|head -c 2897)
@@ -3236,7 +3236,7 @@ FOR1;var y=2;} while(0);}") does not lead to throwing exception"}]
 3203	FAIL (tail -c +3397211 tests/ecmac.db|head -c 923): [{"message":"[parseInt] is not defined"}]
 3204	FAIL (tail -c +3398135 tests/ecmac.db|head -c 3138): [{"message":"[isNaN] is not defined"}]
 3205	FAIL (tail -c +3401274 tests/ecmac.db|head -c 1144): [{"message":"[parseInt] is not defined"}]
-3206	PASS (tail -c +3402419 tests/ecmac.db|head -c 1193)
+3206	FAIL (tail -c +3402419 tests/ecmac.db|head -c 1193): [{"message":"[parseInt] is not defined"}]
 3207	FAIL (tail -c +3403613 tests/ecmac.db|head -c 1179): [{"message":"[parseInt] is not defined"}]
 3208	FAIL (tail -c +3404793 tests/ecmac.db|head -c 685): [{"message":"[parseInt] is not defined"}]
 3209	FAIL (tail -c +3405479 tests/ecmac.db|head -c 683): [{"message":"[parseInt] is not defined"}]
@@ -3294,7 +3294,7 @@ FOR1;var y=2;} while(0);}") does not lead to throwing exception"}]
 3261	FAIL (tail -c +3468263 tests/ecmac.db|head -c 1171): [{"message":"[parseFloat] is not defined"}]
 3262	FAIL (tail -c +3469435 tests/ecmac.db|head -c 3194): [{"message":"[isNaN] is not defined"}]
 3263	FAIL (tail -c +3472630 tests/ecmac.db|head -c 1250): [{"message":"[parseFloat] is not defined"}]
-3264	PASS (tail -c +3473881 tests/ecmac.db|head -c 1212)
+3264	FAIL (tail -c +3473881 tests/ecmac.db|head -c 1212): [{"message":"[parseFloat] is not defined"}]
 3265	FAIL (tail -c +3475094 tests/ecmac.db|head -c 1285): [{"message":"[parseFloat] is not defined"}]
 3266	FAIL (tail -c +3476380 tests/ecmac.db|head -c 731): [{"message":"[parseFloat] is not defined"}]
 3267	FAIL (tail -c +3477112 tests/ecmac.db|head -c 729): [{"message":"[parseFloat] is not defined"}]
@@ -3343,12 +3343,12 @@ FOR1;var y=2;} while(0);}") does not lead to throwing exception"}]
 3310	PASS (tail -c +3516478 tests/ecmac.db|head -c 658)
 3311	FAIL (tail -c +3517137 tests/ecmac.db|head -c 357): [{"message":"[isFinite] is not defined"}]
 3312	FAIL (tail -c +3517495 tests/ecmac.db|head -c 536): [{"message":"#1.2: new isFinite() throw TypeError. Actual: {"message":"[isFinite] is not defined"}"}]
-3313	PASS (tail -c +3518032 tests/ecmac.db|head -c 943)
-3314	PASS (tail -c +3518976 tests/ecmac.db|head -c 1093)
-3315	PASS (tail -c +3520070 tests/ecmac.db|head -c 1093)
-3316	PASS (tail -c +3521164 tests/ecmac.db|head -c 1151)
-3317	PASS (tail -c +3522316 tests/ecmac.db|head -c 1156)
-3318	PASS (tail -c +3523473 tests/ecmac.db|head -c 1155)
+3313	FAIL (tail -c +3518032 tests/ecmac.db|head -c 943): [{"message":"[URIError] is not defined"}]
+3314	FAIL (tail -c +3518976 tests/ecmac.db|head -c 1093): [{"message":"[URIError] is not defined"}]
+3315	FAIL (tail -c +3520070 tests/ecmac.db|head -c 1093): [{"message":"[URIError] is not defined"}]
+3316	FAIL (tail -c +3521164 tests/ecmac.db|head -c 1151): [{"message":"[URIError] is not defined"}]
+3317	FAIL (tail -c +3522316 tests/ecmac.db|head -c 1156): [{"message":"[URIError] is not defined"}]
+3318	FAIL (tail -c +3523473 tests/ecmac.db|head -c 1155): [{"message":"[URIError] is not defined"}]
 3319	FAIL (tail -c +3524629 tests/ecmac.db|head -c 2241): [{"message":"[URIError] is not defined"}]
 3320	FAIL (tail -c +3526871 tests/ecmac.db|head -c 2241): [{"message":"[URIError] is not defined"}]
 3321	FAIL (tail -c +3529113 tests/ecmac.db|head -c 2248): [{"message":"[URIError] is not defined"}]
@@ -3362,8 +3362,8 @@ FOR1;var y=2;} while(0);}") does not lead to throwing exception"}]
 3329	FAIL (tail -c +3547128 tests/ecmac.db|head -c 2257): [{"message":"[URIError] is not defined"}]
 3330	FAIL (tail -c +3549386 tests/ecmac.db|head -c 2252): [{"message":"[URIError] is not defined"}]
 3331	FAIL (tail -c +3551639 tests/ecmac.db|head -c 913): [{"message":"[URIError] is not defined"}]
-3332	PASS (tail -c +3552553 tests/ecmac.db|head -c 841)
-3333	PASS (tail -c +3553395 tests/ecmac.db|head -c 843)
+3332	FAIL (tail -c +3552553 tests/ecmac.db|head -c 841): [{"message":"[URIError] is not defined"}]
+3333	FAIL (tail -c +3553395 tests/ecmac.db|head -c 843): [{"message":"[URIError] is not defined"}]
 3334	FAIL (tail -c +3554239 tests/ecmac.db|head -c 1942): [{"message":"[URIError] is not defined"}]
 3335	FAIL (tail -c +3556182 tests/ecmac.db|head -c 1942): [{"message":"[URIError] is not defined"}]
 3336	FAIL (tail -c +3558125 tests/ecmac.db|head -c 2152): [{"message":"[URIError] is not defined"}]
@@ -3393,12 +3393,12 @@ FOR1;var y=2;} while(0);}") does not lead to throwing exception"}]
 3362	FAIL (tail -c +3598322 tests/ecmac.db|head -c 363): [{"message":"[decodeURI] is not defined"}]
 3363	FAIL (tail -c +3598686 tests/ecmac.db|head -c 541): [{"message":"#1.2: new decodeURI() throw TypeError. Actual: {"message":"[decodeURI] is not defined"}"}]
 3364	FAIL (tail -c +3599228 tests/ecmac.db|head -c 3265): [{"message":"[decodeURI] is not defined"}]
-3365	PASS (tail -c +3602494 tests/ecmac.db|head -c 940)
-3366	PASS (tail -c +3603435 tests/ecmac.db|head -c 1090)
-3367	PASS (tail -c +3604526 tests/ecmac.db|head -c 1090)
-3368	PASS (tail -c +3605617 tests/ecmac.db|head -c 1148)
-3369	PASS (tail -c +3606766 tests/ecmac.db|head -c 1153)
-3370	PASS (tail -c +3607920 tests/ecmac.db|head -c 1152)
+3365	FAIL (tail -c +3602494 tests/ecmac.db|head -c 940): [{"message":"[URIError] is not defined"}]
+3366	FAIL (tail -c +3603435 tests/ecmac.db|head -c 1090): [{"message":"[URIError] is not defined"}]
+3367	FAIL (tail -c +3604526 tests/ecmac.db|head -c 1090): [{"message":"[URIError] is not defined"}]
+3368	FAIL (tail -c +3605617 tests/ecmac.db|head -c 1148): [{"message":"[URIError] is not defined"}]
+3369	FAIL (tail -c +3606766 tests/ecmac.db|head -c 1153): [{"message":"[URIError] is not defined"}]
+3370	FAIL (tail -c +3607920 tests/ecmac.db|head -c 1152): [{"message":"[URIError] is not defined"}]
 3371	FAIL (tail -c +3609073 tests/ecmac.db|head -c 2222): [{"message":"[URIError] is not defined"}]
 3372	FAIL (tail -c +3611296 tests/ecmac.db|head -c 2222): [{"message":"[URIError] is not defined"}]
 3373	FAIL (tail -c +3613519 tests/ecmac.db|head -c 2229): [{"message":"[URIError] is not defined"}]
@@ -3412,8 +3412,8 @@ FOR1;var y=2;} while(0);}") does not lead to throwing exception"}]
 3381	FAIL (tail -c +3631382 tests/ecmac.db|head -c 2238): [{"message":"[URIError] is not defined"}]
 3382	FAIL (tail -c +3633621 tests/ecmac.db|head -c 2233): [{"message":"[URIError] is not defined"}]
 3383	FAIL (tail -c +3635855 tests/ecmac.db|head -c 945): [{"message":"[URIError] is not defined"}]
-3384	PASS (tail -c +3636801 tests/ecmac.db|head -c 838)
-3385	PASS (tail -c +3637640 tests/ecmac.db|head -c 840)
+3384	FAIL (tail -c +3636801 tests/ecmac.db|head -c 838): [{"message":"[URIError] is not defined"}]
+3385	FAIL (tail -c +3637640 tests/ecmac.db|head -c 840): [{"message":"[URIError] is not defined"}]
 3386	FAIL (tail -c +3638481 tests/ecmac.db|head -c 1935): [{"message":"[URIError] is not defined"}]
 3387	FAIL (tail -c +3640417 tests/ecmac.db|head -c 1935): [{"message":"[URIError] is not defined"}]
 3388	FAIL (tail -c +3642353 tests/ecmac.db|head -c 2133): [{"message":"[URIError] is not defined"}]
@@ -3448,17 +3448,17 @@ FOR1;var y=2;} while(0);}") does not lead to throwing exception"}]
 3418	FAIL (tail -c +3689168 tests/ecmac.db|head -c 1913): [{"message":"[URIError] is not defined"}]
 3419	FAIL (tail -c +3691082 tests/ecmac.db|head -c 1932): [{"message":"[URIError] is not defined"}]
 3420	FAIL (tail -c +3693015 tests/ecmac.db|head -c 1941): [{"message":"[URIError] is not defined"}]
-3421	PASS (tail -c +3694957 tests/ecmac.db|head -c 2268)
+3421	FAIL (tail -c +3694957 tests/ecmac.db|head -c 2268): [{"message":"[URIError] is not defined"}]
 3422	FAIL (tail -c +3697226 tests/ecmac.db|head -c 2684): [{"message":"i_eval_expr: LABEL"}]
 3423	FAIL (tail -c +3699911 tests/ecmac.db|head -c 2078): [{"message":"i_eval_expr: LABEL"}]
 3424	FAIL (tail -c +3701990 tests/ecmac.db|head -c 2175): [{"message":"value is not a function"}]
-3425	PASS (tail -c +3704166 tests/ecmac.db|head -c 2695)
-3426	PASS (tail -c +3706862 tests/ecmac.db|head -c 2693)
+3425	FAIL (tail -c +3704166 tests/ecmac.db|head -c 2695): [{"message":"value is not a function"}]
+3426	FAIL (tail -c +3706862 tests/ecmac.db|head -c 2693): [{"message":"value is not a function"}]
 3427	FAIL (tail -c +3709556 tests/ecmac.db|head -c 2175): [{"message":"value is not a function"}]
-3428	PASS (tail -c +3711732 tests/ecmac.db|head -c 514)
-3429	PASS (tail -c +3712247 tests/ecmac.db|head -c 743)
-3430	PASS (tail -c +3712991 tests/ecmac.db|head -c 548)
-3431	PASS (tail -c +3713540 tests/ecmac.db|head -c 523)
+3428	FAIL (tail -c +3711732 tests/ecmac.db|head -c 514): [{"message":"[encodeURI] is not defined"}]
+3429	FAIL (tail -c +3712247 tests/ecmac.db|head -c 743): [{"message":"[encodeURI] is not defined"}]
+3430	FAIL (tail -c +3712991 tests/ecmac.db|head -c 548): [{"message":"[encodeURI] is not defined"}]
+3431	FAIL (tail -c +3713540 tests/ecmac.db|head -c 523): [{"message":"[encodeURI] is not defined"}]
 3432	FAIL (tail -c +3714064 tests/ecmac.db|head -c 285): [{"message":"[encodeURI] is not defined"}]
 3433	FAIL (tail -c +3714350 tests/ecmac.db|head -c 750): [{"message":"[encodeURI] is not defined"}]
 3434	FAIL (tail -c +3715101 tests/ecmac.db|head -c 1622): [{"message":"[encodeURI] is not defined"}]
@@ -3476,17 +3476,17 @@ FOR1;var y=2;} while(0);}") does not lead to throwing exception"}]
 3446	FAIL (tail -c +3727588 tests/ecmac.db|head -c 1922): [{"message":"[URIError] is not defined"}]
 3447	FAIL (tail -c +3729511 tests/ecmac.db|head -c 1941): [{"message":"[URIError] is not defined"}]
 3448	FAIL (tail -c +3731453 tests/ecmac.db|head -c 1950): [{"message":"[URIError] is not defined"}]
-3449	PASS (tail -c +3733404 tests/ecmac.db|head -c 2277)
+3449	FAIL (tail -c +3733404 tests/ecmac.db|head -c 2277): [{"message":"[URIError] is not defined"}]
 3450	FAIL (tail -c +3735682 tests/ecmac.db|head -c 2463): [{"message":"i_eval_expr: LABEL"}]
 3451	FAIL (tail -c +3738146 tests/ecmac.db|head -c 2087): [{"message":"i_eval_expr: LABEL"}]
 3452	FAIL (tail -c +3740234 tests/ecmac.db|head -c 2184): [{"message":"value is not a function"}]
-3453	PASS (tail -c +3742419 tests/ecmac.db|head -c 2704)
-3454	PASS (tail -c +3745124 tests/ecmac.db|head -c 2702)
+3453	FAIL (tail -c +3742419 tests/ecmac.db|head -c 2704): [{"message":"value is not a function"}]
+3454	FAIL (tail -c +3745124 tests/ecmac.db|head -c 2702): [{"message":"value is not a function"}]
 3455	FAIL (tail -c +3747827 tests/ecmac.db|head -c 2184): [{"message":"value is not a function"}]
 3456	FAIL (tail -c +3750012 tests/ecmac.db|head -c 615): [{"message":"[encodeURIComponent] is not defined"}]
-3457	PASS (tail -c +3750628 tests/ecmac.db|head -c 761)
-3458	PASS (tail -c +3751390 tests/ecmac.db|head -c 566)
-3459	PASS (tail -c +3751957 tests/ecmac.db|head -c 541)
+3457	FAIL (tail -c +3750628 tests/ecmac.db|head -c 761): [{"message":"[encodeURIComponent] is not defined"}]
+3458	FAIL (tail -c +3751390 tests/ecmac.db|head -c 566): [{"message":"[encodeURIComponent] is not defined"}]
+3459	FAIL (tail -c +3751957 tests/ecmac.db|head -c 541): [{"message":"[encodeURIComponent] is not defined"}]
 3460	FAIL (tail -c +3752499 tests/ecmac.db|head -c 335): [{"message":"[encodeURIComponent] is not defined"}]
 3461	FAIL (tail -c +3752835 tests/ecmac.db|head -c 671): [{"message":"[encodeURIComponent] is not defined"}]
 3462	FAIL (tail -c +3753507 tests/ecmac.db|head -c 1744): [{"message":"[encodeURIComponent] is not defined"}]
@@ -3521,7 +3521,7 @@ FOR1;var y=2;} while(0);}") does not lead to throwing exception"}]
 3491	FAIL (tail -c +3773516 tests/ecmac.db|head -c 516): [{"message":"Test case returned non-true value!"}]
 3492	FAIL (tail -c +3774033 tests/ecmac.db|head -c 420): [{"message":"Test case returned non-true value!"}]
 3493	FAIL (tail -c +3774454 tests/ecmac.db|head -c 456): [{"message":"Test case returned non-true value!"}]
-3494	PASS (tail -c +3774911 tests/ecmac.db|head -c 3461)
+3494	FAIL (tail -c +3774911 tests/ecmac.db|head -c 3461): [{"message":"#0: XML Shallow Parsing with Regular Expression: [^<]+"}]
 3495	FAIL (tail -c +3778373 tests/ecmac.db|head -c 701): [{"message":"i_eval_expr: REGEX"}]
 3496	FAIL (tail -c +3779075 tests/ecmac.db|head -c 701): [{"message":"i_eval_expr: REGEX"}]
 3497	FAIL (tail -c +3779777 tests/ecmac.db|head -c 701): [{"message":"i_eval_expr: REGEX"}]
@@ -3531,10 +3531,10 @@ FOR1;var y=2;} while(0);}") does not lead to throwing exception"}]
 3501	FAIL (tail -c +3782439 tests/ecmac.db|head -c 555): [{"message":"value is not a function"}]
 3502	FAIL (tail -c +3782995 tests/ecmac.db|head -c 893): [{"message":"value is not a function"}]
 3503	FAIL (tail -c +3783889 tests/ecmac.db|head -c 1030): [{"message":"i_eval_expr: REGEX"}]
-3504	PASS (tail -c +3784920 tests/ecmac.db|head -c 1628)
+3504	FAIL (tail -c +3784920 tests/ecmac.db|head -c 1628): [{"message":"[RegExp] is not defined"}]
 3505	FAIL (tail -c +3786549 tests/ecmac.db|head -c 1466): [{"message":"i_eval_expr: REGEX"}]
-3506	PASS (tail -c +3788016 tests/ecmac.db|head -c 1767)
-3507	PASS (tail -c +3789784 tests/ecmac.db|head -c 2361)
+3506	FAIL (tail -c +3788016 tests/ecmac.db|head -c 1767): [{"message":"[RegExp] is not defined"}]
+3507	FAIL (tail -c +3789784 tests/ecmac.db|head -c 2361): [{"message":"[RegExp] is not defined"}]
 3508	FAIL (tail -c +3792146 tests/ecmac.db|head -c 625): [{"message":"[RegExp] is not defined"}]
 3509	FAIL (tail -c +3792772 tests/ecmac.db|head -c 738): [{"message":"i_eval_expr: REGEX"}]
 3510	FAIL (tail -c +3793511 tests/ecmac.db|head -c 587): [{"message":"i_eval_expr: REGEX"}]
@@ -4408,7 +4408,7 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 4376	FAIL (tail -c +4742915 tests/ecmac.db|head -c 390): [{"message":"value is not a function"}]
 4377	FAIL (tail -c +4743306 tests/ecmac.db|head -c 387): [{"message":"value is not a function"}]
 4378	FAIL (tail -c +4743694 tests/ecmac.db|head -c 387): [{"message":"value is not a function"}]
-4379	FAIL (tail -c +4744082 tests/ecmac.db|head -c 751): [{"message":"Test case returned non-true value!"}]
+4379	PASS (tail -c +4744082 tests/ecmac.db|head -c 751)
 4380	FAIL (tail -c +4744834 tests/ecmac.db|head -c 904): [{"message":"Test case returned non-true value!"}]
 4381	FAIL (tail -c +4745739 tests/ecmac.db|head -c 437): [{"message":"Test case returned non-true value!"}]
 4382	FAIL (tail -c +4746177 tests/ecmac.db|head -c 438): [{"message":"Test case returned non-true value!"}]
@@ -4424,8 +4424,8 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 4392	PASS (tail -c +4752738 tests/ecmac.db|head -c 801)
 4393	FAIL (tail -c +4753540 tests/ecmac.db|head -c 1049): [{"message":"value is not a function"}]
 4394	PASS (tail -c +4754590 tests/ecmac.db|head -c 758)
-4395	PASS (tail -c +4755349 tests/ecmac.db|head -c 763)
-4396	PASS (tail -c +4756113 tests/ecmac.db|head -c 935)
+4395	FAIL (tail -c +4755349 tests/ecmac.db|head -c 763): [{"message":"Test case returned non-true value!"}]
+4396	FAIL (tail -c +4756113 tests/ecmac.db|head -c 935): [{"message":"Test case returned non-true value!"}]
 4397	PASS (tail -c +4757049 tests/ecmac.db|head -c 616)
 4398	PASS (tail -c +4757666 tests/ecmac.db|head -c 905)
 4399	PASS (tail -c +4758572 tests/ecmac.db|head -c 1057)
@@ -4797,11 +4797,11 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 4765	PASS (tail -c +4962724 tests/ecmac.db|head -c 428)
 4766	FAIL (tail -c +4963153 tests/ecmac.db|head -c 408): [{"message":"value is not a function"}]
 4767	FAIL (tail -c +4963562 tests/ecmac.db|head -c 393): [{"message":"Expecting a function in instanceof check"}]
-4768	FAIL (tail -c +4963956 tests/ecmac.db|head -c 397): [{"message":"Test case returned non-true value!"}]
+4768	PASS (tail -c +4963956 tests/ecmac.db|head -c 397)
 4769	FAIL (tail -c +4964354 tests/ecmac.db|head -c 717): [{"message":"Test case returned non-true value!"}]
 4770	PASS (tail -c +4965072 tests/ecmac.db|head -c 436)
 4771	FAIL (tail -c +4965509 tests/ecmac.db|head -c 999): [{"message":"Test case returned non-true value!"}]
-4772	PASS (tail -c +4966509 tests/ecmac.db|head -c 629)
+4772	FAIL (tail -c +4966509 tests/ecmac.db|head -c 629): [{"message":"Test case returned non-true value!"}]
 4773	PASS (tail -c +4967139 tests/ecmac.db|head -c 666)
 4774	PASS (tail -c +4967806 tests/ecmac.db|head -c 825)
 4775	PASS (tail -c +4968632 tests/ecmac.db|head -c 418)
@@ -4810,12 +4810,12 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 4778	PASS (tail -c +4970400 tests/ecmac.db|head -c 937)
 4779	PASS (tail -c +4971338 tests/ecmac.db|head -c 699)
 4780	PASS (tail -c +4972038 tests/ecmac.db|head -c 755)
-4781	FAIL (tail -c +4972794 tests/ecmac.db|head -c 538): [{"message":"value is not a function"}]
+4781	FAIL (tail -c +4972794 tests/ecmac.db|head -c 538): [{"message":"Test case returned non-true value!"}]
 4782	PASS (tail -c +4973333 tests/ecmac.db|head -c 759)
 4783	PASS (tail -c +4974093 tests/ecmac.db|head -c 926)
 4784	PASS (tail -c +4975020 tests/ecmac.db|head -c 596)
 4785	PASS (tail -c +4975617 tests/ecmac.db|head -c 746)
-4786	FAIL (tail -c +4976364 tests/ecmac.db|head -c 499): [{"message":"value is not a function"}]
+4786	FAIL (tail -c +4976364 tests/ecmac.db|head -c 499): [{"message":"Test case returned non-true value!"}]
 4787	PASS (tail -c +4976864 tests/ecmac.db|head -c 598)
 4788	PASS (tail -c +4977463 tests/ecmac.db|head -c 565)
 4789	FAIL (tail -c +4978029 tests/ecmac.db|head -c 1021): [{"message":"value is not a function"}]
@@ -5706,7 +5706,7 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 5674	FAIL (tail -c +5631460 tests/ecmac.db|head -c 1104): [{"message":"Test case returned non-true value!"}]
 5675	PASS (tail -c +5632565 tests/ecmac.db|head -c 706)
 5676	FAIL (tail -c +5633272 tests/ecmac.db|head -c 720): [{"message":"Test case returned non-true value!"}]
-5677	FAIL (tail -c +5633993 tests/ecmac.db|head -c 615): [{"message":"Test case returned non-true value!"}]
+5677	PASS (tail -c +5633993 tests/ecmac.db|head -c 615)
 5678	PASS (tail -c +5634609 tests/ecmac.db|head -c 719)
 5679	FAIL (tail -c +5635329 tests/ecmac.db|head -c 899): [{"message":"Test case returned non-true value!"}]
 5680	FAIL (tail -c +5636229 tests/ecmac.db|head -c 1105): [{"message":"Test case returned non-true value!"}]
@@ -6736,8 +6736,8 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 6704	FAIL (tail -c +6557047 tests/ecmac.db|head -c 1263): [{"message":"Test case returned non-true value!"}]
 6705	PASS (tail -c +6558311 tests/ecmac.db|head -c 725)
 6706	FAIL (tail -c +6559037 tests/ecmac.db|head -c 738): [{"message":"Test case returned non-true value!"}]
-6707	FAIL (tail -c +6559776 tests/ecmac.db|head -c 634): [{"message":"Test case returned non-true value!"}]
-6708	FAIL (tail -c +6560411 tests/ecmac.db|head -c 773): [{"message":"Test case returned non-true value!"}]
+6707	PASS (tail -c +6559776 tests/ecmac.db|head -c 634)
+6708	PASS (tail -c +6560411 tests/ecmac.db|head -c 773)
 6709	FAIL (tail -c +6561185 tests/ecmac.db|head -c 957): [{"message":"Test case returned non-true value!"}]
 6710	FAIL (tail -c +6562143 tests/ecmac.db|head -c 1083): [{"message":"Test case returned non-true value!"}]
 6711	FAIL (tail -c +6563227 tests/ecmac.db|head -c 842): [{"message":"Test case returned non-true value!"}]
@@ -7367,30 +7367,30 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 7335	FAIL (tail -c +7011656 tests/ecmac.db|head -c 956): [{"message":"value is not a function"}]
 7336	FAIL (tail -c +7012613 tests/ecmac.db|head -c 516): [{"message":"value is not a function"}]
 7337	FAIL (tail -c +7013130 tests/ecmac.db|head -c 741): [{"message":"value is not a function"}]
-7338	FAIL (tail -c +7013872 tests/ecmac.db|head -c 511): [{"message":"#2: var x = Array(2); x[0] !== 2"}]
-7339	FAIL (tail -c +7014384 tests/ecmac.db|head -c 701): [{"message":"#1: (Array().length === 0. Actual: undefined"}]
+7338	FAIL (tail -c +7013872 tests/ecmac.db|head -c 511): [{"message":"#1: var x = Array(2); x.length !== 1"}]
+7339	PASS (tail -c +7014384 tests/ecmac.db|head -c 701)
 7340	PASS (tail -c +7015086 tests/ecmac.db|head -c 1031)
 7341	FAIL (tail -c +7016118 tests/ecmac.db|head -c 557): [{"message":"Expecting a function in instanceof check"}]
 7342	FAIL (tail -c +7016676 tests/ecmac.db|head -c 821): [{"message":"#1: Array.prototype.myproperty = 1; var x = new Array(); x.myproperty === 1. Actual: undefined"}]
 7343	FAIL (tail -c +7017498 tests/ecmac.db|head -c 983): [{"message":"value is not a function"}]
 7344	FAIL (tail -c +7018482 tests/ecmac.db|head -c 539): [{"message":"value is not a function"}]
 7345	FAIL (tail -c +7019022 tests/ecmac.db|head -c 768): [{"message":"value is not a function"}]
-7346	FAIL (tail -c +7019791 tests/ecmac.db|head -c 534): [{"message":"#2: var x = new Array(2); x[0] !== 2"}]
-7347	FAIL (tail -c +7020326 tests/ecmac.db|head -c 745): [{"message":"#1: new Array().length === 0. Actual: undefined"}]
+7346	FAIL (tail -c +7019791 tests/ecmac.db|head -c 534): [{"message":"#1: var x = new Array(2); x.length !== 1"}]
+7347	PASS (tail -c +7020326 tests/ecmac.db|head -c 745)
 7348	PASS (tail -c +7021072 tests/ecmac.db|head -c 1046)
 7349	FAIL (tail -c +7022119 tests/ecmac.db|head -c 604): [{"message":"#1: Array.prototype.myproperty = 1; var x = new Array(0); x.myproperty === 1. Actual: undefined"}]
 7350	FAIL (tail -c +7022724 tests/ecmac.db|head -c 671): [{"message":"value is not a function"}]
 7351	FAIL (tail -c +7023396 tests/ecmac.db|head -c 542): [{"message":"value is not a function"}]
 7352	FAIL (tail -c +7023939 tests/ecmac.db|head -c 511): [{"message":"value is not a function"}]
-7353	FAIL (tail -c +7024451 tests/ecmac.db|head -c 784): [{"message":"#1: var x = new Array(0); x.length === 0. Actual: undefined"}]
+7353	FAIL (tail -c +7024451 tests/ecmac.db|head -c 784): [{"message":"#1: var x = new Array(0); x.length === 0. Actual: 1"}]
 7354	FAIL (tail -c +7025236 tests/ecmac.db|head -c 1115): [{"message":"[RangeError] is not defined"}]
 7355	FAIL (tail -c +7026352 tests/ecmac.db|head -c 1221): [{"message":"[RangeError] is not defined"}]
 7356	FAIL (tail -c +7027574 tests/ecmac.db|head -c 1180): [{"message":"[RangeError] is not defined"}]
-7357	FAIL (tail -c +7028755 tests/ecmac.db|head -c 884): [{"message":"#1: var x = new Array(null); x.length === 1. Actual: undefined"}]
-7358	FAIL (tail -c +7029640 tests/ecmac.db|head -c 962): [{"message":"#1: var x = new Array(true); x.length === 1. Actual: undefined"}]
-7359	FAIL (tail -c +7030603 tests/ecmac.db|head -c 948): [{"message":"#1: var x = new Array("1"); x.length === 1. Actual: undefined"}]
-7360	FAIL (tail -c +7031552 tests/ecmac.db|head -c 1343): [{"message":"#1: var obj = new Number(0); var x = new Array(obj); x.length === 1. Actual: undefined"}]
-7361	FAIL (tail -c +7032896 tests/ecmac.db|head -c 1373): [{"message":"#1: var obj = new Number(-1); var x = new Array(obj); x.length === 1. Actual: undefined"}]
+7357	PASS (tail -c +7028755 tests/ecmac.db|head -c 884)
+7358	PASS (tail -c +7029640 tests/ecmac.db|head -c 962)
+7359	PASS (tail -c +7030603 tests/ecmac.db|head -c 948)
+7360	PASS (tail -c +7031552 tests/ecmac.db|head -c 1343)
+7361	PASS (tail -c +7032896 tests/ecmac.db|head -c 1373)
 7362	FAIL (tail -c +7034270 tests/ecmac.db|head -c 729): [{"message":"[Function] is not defined"}]
 7363	FAIL (tail -c +7035000 tests/ecmac.db|head -c 587): [{"message":"[Function] is not defined"}]
 7364	FAIL (tail -c +7035588 tests/ecmac.db|head -c 463): [{"message":"[Function] is not defined"}]
@@ -7567,7 +7567,7 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 7535	PASS (tail -c +7209698 tests/ecmac.db|head -c 423)
 7536	PASS (tail -c +7210122 tests/ecmac.db|head -c 601)
 7537	FAIL (tail -c +7210724 tests/ecmac.db|head -c 1501): [{"message":"value is not a function"}]
-7538	FAIL (tail -c +7212226 tests/ecmac.db|head -c 1881): [{"message":"#1: x = []; x.length === 0. Actual: undefined"}]
+7538	FAIL (tail -c +7212226 tests/ecmac.db|head -c 1881): [{"message":"value is not a function"}]
 7539	FAIL (tail -c +7214108 tests/ecmac.db|head -c 2349): [{"message":"value is not a function"}]
 7540	FAIL (tail -c +7216458 tests/ecmac.db|head -c 4201): [{"message":"value is not a function"}]
 7541	FAIL (tail -c +7220660 tests/ecmac.db|head -c 3364): [{"message":"value is not a function"}]
@@ -9597,7 +9597,7 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 9565	PASS (tail -c +8661918 tests/ecmac.db|head -c 406)
 9566	PASS (tail -c +8662325 tests/ecmac.db|head -c 584)
 9567	FAIL (tail -c +8662910 tests/ecmac.db|head -c 1287): [{"message":"#3: x = new Array(); x.push(1); x.push() === 1. Actual: undefined"}]
-9568	FAIL (tail -c +8664198 tests/ecmac.db|head -c 1833): [{"message":"#1: x = []; x.length === 0. Actual: undefined"}]
+9568	FAIL (tail -c +8664198 tests/ecmac.db|head -c 1833): [{"message":"#2: x = []; x[0] = 0; x.push(true, Number.POSITIVE_INFINITY, "NaN", "1", -1) === 6. Actual: -1"}]
 9569	FAIL (tail -c +8666032 tests/ecmac.db|head -c 2209): [{"message":"value is not a function"}]
 9570	FAIL (tail -c +8668242 tests/ecmac.db|head -c 3948): [{"message":"value is not a function"}]
 9571	FAIL (tail -c +8672191 tests/ecmac.db|head -c 3224): [{"message":"value is not a function"}]
@@ -9662,12 +9662,12 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 9630	FAIL (tail -c +8759574 tests/ecmac.db|head -c 808): [{"message":"#2: Array.prototype[2] = 2; x = [0,1]; x.length = 3; x.length = 2; x[2] === 2. Actual: undefined"}]
 9631	FAIL (tail -c +8760383 tests/ecmac.db|head -c 1183): [{"message":"#1: x = []; x.length = true; x.length === 1. Actual: true"}]
 9632	FAIL (tail -c +8761567 tests/ecmac.db|head -c 3045): [{"message":"#1: x = []; x.length = {valueOf: function() {return 2}};  x.length === 2. Actual: {"valueOf":[function()]}"}]
-9633	FAIL (tail -c +8764613 tests/ecmac.db|head -c 1061): [{"message":"#1.1: x = []; x[4294967295] = 1; x.length === 0. Actual: undefined"}]
-9634	FAIL (tail -c +8765675 tests/ecmac.db|head -c 726): [{"message":"#1: x = Array(100); x[0] = 1; x.length === 100. Actual: undefined"}]
-9635	FAIL (tail -c +8766402 tests/ecmac.db|head -c 600): [{"message":"#1: x = Array(100); x[100] = 1; x.length === 101. Actual: undefined"}]
-9636	FAIL (tail -c +8767003 tests/ecmac.db|head -c 1149): [{"message":"#1: x = []; x.length === 0. Actual: undefined"}]
-9637	FAIL (tail -c +8768153 tests/ecmac.db|head -c 731): [{"message":"#1: x = []; x[4294967295] = 1; x.length === 0. Actual: undefined"}]
-9638	FAIL (tail -c +8768885 tests/ecmac.db|head -c 778): [{"message":"#1: x = []; x.length === 0. Actual: undefined"}]
+9633	FAIL (tail -c +8764613 tests/ecmac.db|head -c 1061): [{"message":"#1.1: x = []; x[4294967295] = 1; x.length === 0. Actual: 5"}]
+9634	FAIL (tail -c +8765675 tests/ecmac.db|head -c 726): [{"message":"#1: x = Array(100); x[0] = 1; x.length === 100. Actual: 1"}]
+9635	PASS (tail -c +8766402 tests/ecmac.db|head -c 600)
+9636	FAIL (tail -c +8767003 tests/ecmac.db|head -c 1149): [{"message":"#4: x = []; x[0] = 1; x[1] = 1; x[2147483648] = 1; x.length === 2147483649. Actual: 3"}]
+9637	FAIL (tail -c +8768153 tests/ecmac.db|head -c 731): [{"message":"#1: x = []; x[4294967295] = 1; x.length === 0. Actual: 5"}]
+9638	PASS (tail -c +8768885 tests/ecmac.db|head -c 778)
 9639	PASS (tail -c +8769664 tests/ecmac.db|head -c 810)
 9640	FAIL (tail -c +8770475 tests/ecmac.db|head -c 1508): [{"message":"#2: x = []; x[1] = 1; x[3] = 3; x[5] = 5; x.length = 4; x[5] === undefined. Actual: 5"}]
 9641	FAIL (tail -c +8771984 tests/ecmac.db|head -c 795): [{"message":"[RangeError] is not defined"}]
@@ -10355,8 +10355,8 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 10323	PASS (tail -c +9450716 tests/ecmac.db|head -c 497)
 10324	FAIL (tail -c +9451214 tests/ecmac.db|head -c 1490): [{"message":"value is not a function"}]
 10325	FAIL (tail -c +9452705 tests/ecmac.db|head -c 1410): [{"message":"value is not a function"}]
-10326	PASS (tail -c +9454116 tests/ecmac.db|head -c 814)
-10327	PASS (tail -c +9454931 tests/ecmac.db|head -c 2076)
+10326	FAIL (tail -c +9454116 tests/ecmac.db|head -c 814): [{"message":"value is not a function"}]
+10327	FAIL (tail -c +9454931 tests/ecmac.db|head -c 2076): [{"message":"value is not a function"}]
 10328	FAIL (tail -c +9457008 tests/ecmac.db|head -c 1277): [{"message":"value is not a function"}]
 10329	FAIL (tail -c +9458286 tests/ecmac.db|head -c 970): [{"message":"value is not a function"}]
 10330	FAIL (tail -c +9459257 tests/ecmac.db|head -c 926): [{"message":"value is not a function"}]
@@ -10365,11 +10365,11 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 10333	PASS (tail -c +9461304 tests/ecmac.db|head -c 538)
 10334	FAIL (tail -c +9461843 tests/ecmac.db|head -c 1443): [{"message":"value is not a function"}]
 10335	FAIL (tail -c +9463287 tests/ecmac.db|head -c 1434): [{"message":"value is not a function"}]
-10336	FAIL (tail -c +9464722 tests/ecmac.db|head -c 1193): [{"message":"#1: var __str__instance = new String("ABCABC"); __str__instance.length === 6, where __str__instance is new String("ABCABC"). Actual: __str__instance.length ===undefined"}]
+10336	PASS (tail -c +9464722 tests/ecmac.db|head -c 1193)
 10337	FAIL (tail -c +9465916 tests/ecmac.db|head -c 985): [{"message":"#1: var __str__instance = new String("globglob"); __str__instance.hasOwnProperty("length") return true. Actual: false"}]
 10338	FAIL (tail -c +9466902 tests/ecmac.db|head -c 1402): [{"message":"#1: var __str__instance = new String("globglob"); __str__instance.hasOwnProperty("length") return true. Actual: false"}]
 10339	FAIL (tail -c +9468305 tests/ecmac.db|head -c 2442): [{"message":"#1: var __str__instance = new String("globglob"); __str__instance.hasOwnProperty("length") return true. Actual: false"}]
-10340	FAIL (tail -c +9470748 tests/ecmac.db|head -c 1752): [{"message":"#1: var __str__instance = new String("ABCABC"); __str__instance.length === 6. Actual: __str__instance.length ===undefined"}]
+10340	FAIL (tail -c +9470748 tests/ecmac.db|head -c 1752): [{"message":"#2: var __str__instance = new String("ABCABC"); __str__instance.valueOf = function(){return "ed"}; __str__instance.toString = function(){return "ed"}; __str__instance =="ed". Actual: __str__instance =={"toString":[function()],"valueOf":[function()],}"}]
 10341	PASS (tail -c +9472501 tests/ecmac.db|head -c 632)
 10342	PASS (tail -c +9473134 tests/ecmac.db|head -c 618)
 10343	PASS (tail -c +9473753 tests/ecmac.db|head -c 669)


### PR DESCRIPTION
This fix reduces coverage, because SUDDENLY loops in tests start to work!  (e.g. `for (i =0; i < arr.length; i++`)