### PR TITLE
Fix ast ne ne

### DIFF
--- a/examples/load_json_config/Makefile
+++ b/examples/load_json_config/Makefile
@@ -6,7 +6,7 @@ CFLAGS = -W -Wall -I../.. $(CFLAGS_EXTRA) $(MODULE_CFLAGS)
 all: $(PROG)
 
 $(PROG): $(SOURCES)
-	$(CC) $(SOURCES) -o $@ $(CFLAGS)
+	$(CC) $(SOURCES) -o $@ $(CFLAGS) -lm
 
 $(PROG).exe: $(SOURCES)
 	cl $(SOURCES) /I../.. /MD /Fe$@

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -257,7 +257,7 @@ static val_t i_eval_expr(struct v7 *v7, struct ast *a, ast_off_t *pos,
       if (v7_is_string(v1) && v7_is_string(v2)) {
         return v7_boolean_to_value(s_cmp(v7, v1, v2) != 0);
       }
-      if (v1 == v2 & v1 == V7_TAG_NAN) {
+      if (v1 == v2 && v1 == V7_TAG_NAN) {
         return v7_boolean_to_value(1);
       }
       return v7_boolean_to_value(v1 != v2);


### PR DESCRIPTION
Fix the compile. And also fix a typo in evaluation of AST_NE_NE. There's a & where a && is intended.