### PR TITLE
Fix setter invocation and add `length` setter

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -27,6 +27,14 @@ static val_t Array_length(struct v7 *v7, val_t this_obj, val_t args) {
   return v7_create_number(v7_array_length(v7, this_obj));
 }
 
+static val_t Array_set_length(struct v7 *v7, val_t this_obj, val_t args) {
+  (void) v7;
+  (void) args;
+  (void) this_obj;
+  /* TODO(mkm): extend or trim array */
+  return V7_UNDEFINED;
+}
+
 static int a_cmp(const void *pa, const void *pb) {
   val_t a = * (val_t *) pa, b = * (val_t *) pb;
   /* TODO(lsm): support comparison for all types, not just numbers */
@@ -85,11 +93,16 @@ static val_t Array_pop(struct v7 *v7, val_t this_obj, val_t args) {
 }
 
 V7_PRIVATE void init_array(struct v7 *v7) {
+  val_t length = v7_create_array(v7);
+
   set_cfunc_obj_prop(v7, v7->global_object, "Array", Array_ctor);
   set_cfunc_obj_prop(v7, v7->array_prototype, "push", Array_push);
   set_cfunc_obj_prop(v7, v7->array_prototype, "sort", Array_sort);
   set_cfunc_obj_prop(v7, v7->array_prototype, "reverse", Array_reverse);
   set_cfunc_obj_prop(v7, v7->array_prototype, "pop", Array_pop);
-  v7_set_property(v7, v7->array_prototype, "length", 6, V7_PROPERTY_GETTER,
-                  v7_create_cfunction(Array_length));
+
+  v7_set(v7, length, "0", 1, v7_create_cfunction(Array_length));
+  v7_set(v7, length, "1", 1, v7_create_cfunction(Array_set_length));
+  v7_set_property(v7, v7->array_prototype, "length", 6,
+                  V7_PROPERTY_GETTER | V7_PROPERTY_SETTER, length);
 }

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -441,6 +441,8 @@ static val_t i_eval_expr(struct v7 *v7, struct ast *a, ast_off_t *pos,
           prop->value = v1;
         } else if (prop != NULL && prop->attributes & V7_PROPERTY_READ_ONLY) {
           /* nop */
+        } else if (prop != NULL && prop->attributes & V7_PROPERTY_SETTER) {
+          v7_invoke_setter(v7, prop, root, v1);
         } else {
           v7_set_property(v7, root, name, name_len, 0, v1);
         }

--- a/src/vm.c
+++ b/src/vm.c
@@ -537,6 +537,16 @@ int v7_set(struct v7 *v7, val_t obj, const char *name, size_t len, val_t val) {
   return -1;
 }
 
+V7_PRIVATE void v7_invoke_setter(struct v7 *v7, struct v7_property *prop,
+                                 val_t obj, val_t val) {
+  val_t setter = prop->value, args = v7_create_array(v7);
+  if (prop->attributes & V7_PROPERTY_GETTER) {
+    setter = v7_array_at(v7, prop->value, 1);
+  }
+  v7_set(v7, args, "0", 1, val);
+  v7_apply(v7, setter, obj, args);
+}
+
 int v7_set_property(struct v7 *v7, val_t obj, const char *name, size_t len,
                     unsigned int attributes, v7_val_t val) {
   struct v7_property *prop;
@@ -563,12 +573,7 @@ int v7_set_property(struct v7 *v7, val_t obj, const char *name, size_t len,
     prop->name[len] = '\0';
   }
   if (prop->attributes & V7_PROPERTY_SETTER) {
-    val_t setter = prop->value, args = v7_create_array(v7);
-    if (prop->attributes & V7_PROPERTY_GETTER) {
-      setter = v7_array_at(v7, prop->value, 1);
-    }
-    v7_set(v7, args, "0", 1, val);
-    v7_apply(v7, setter, obj, args);
+    v7_invoke_setter(v7, prop, obj, val);
     return 0;
   }
   prop->value = val;

--- a/src/vm.h
+++ b/src/vm.h
@@ -158,6 +158,8 @@ V7_PRIVATE struct v7_property *v7_get_own_property2(val_t obj, const char *name,
 /* If `len` is -1/MAXUINT/~0, then `name` must be 0-terminated */
 V7_PRIVATE struct v7_property *v7_get_property(val_t obj, const char *name,
                                                size_t);
+V7_PRIVATE void v7_invoke_setter(struct v7 *, struct v7_property *, val_t,
+                                 val_t);
 V7_PRIVATE int v7_set_property(struct v7 *, v7_val_t obj, const char *name,
                                size_t len, unsigned int attributes,
                                v7_val_t val);

--- a/tests/ecma_report.txt
+++ b/tests/ecma_report.txt
@@ -1210,7 +1210,7 @@
 1206	FAIL ch10/10.6/S10.6_A5_T1.js (tail -c +851893 tests/ecmac.db|head -c 745): [{"message":"#1: arguments object doesn't exists"}]
 1207	PASS ch10/10.6/S10.6_A5_T2.js (tail -c +852639 tests/ecmac.db|head -c 846)
 1208	PASS ch10/10.6/S10.6_A5_T3.js (tail -c +853486 tests/ecmac.db|head -c 711)
-1209	PASS ch10/10.6/S10.6_A5_T4.js (tail -c +854198 tests/ecmac.db|head -c 776)
+1209	FAIL ch10/10.6/S10.6_A5_T4.js (tail -c +854198 tests/ecmac.db|head -c 776): [{"message":"#1: arguments object don't exists"}]
 1210	PASS ch10/10.6/S10.6_A6.js (tail -c +854975 tests/ecmac.db|head -c 1136)
 1211	PASS ch10/10.6/S10.6_A7.js (tail -c +856112 tests/ecmac.db|head -c 386)
 1212	PASS ch11/11.1/11.1.1/11.1.1-1gs.js (tail -c +856499 tests/ecmac.db|head -c 287)
@@ -5726,8 +5726,8 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 5672	FAIL ch15/15.2/15.2.3/15.2.3.6/15.2.3.6-4-271.js (tail -c +5629656 tests/ecmac.db|head -c 915): [{"message":"Test case returned non-true value!"}]
 5673	FAIL ch15/15.2/15.2.3/15.2.3.6/15.2.3.6-4-272.js (tail -c +5630572 tests/ecmac.db|head -c 887): [{"message":"Test case returned non-true value!"}]
 5674	FAIL ch15/15.2/15.2.3/15.2.3.6/15.2.3.6-4-273.js (tail -c +5631460 tests/ecmac.db|head -c 1104): [{"message":"Test case returned non-true value!"}]
-5675	PASS ch15/15.2/15.2.3/15.2.3.6/15.2.3.6-4-274.js (tail -c +5632565 tests/ecmac.db|head -c 706)
-5676	FAIL ch15/15.2/15.2.3/15.2.3.6/15.2.3.6-4-275.js (tail -c +5633272 tests/ecmac.db|head -c 720): [{"message":"Test case returned non-true value!"}]
+5675	FAIL ch15/15.2/15.2.3/15.2.3.6/15.2.3.6-4-274.js (tail -c +5632565 tests/ecmac.db|head -c 706): [{"message":"Test case returned non-true value!"}]
+5676	PASS ch15/15.2/15.2.3/15.2.3.6/15.2.3.6-4-275.js (tail -c +5633272 tests/ecmac.db|head -c 720)
 5677	PASS ch15/15.2/15.2.3/15.2.3.6/15.2.3.6-4-276.js (tail -c +5633993 tests/ecmac.db|head -c 615)
 5678	PASS ch15/15.2/15.2.3/15.2.3.6/15.2.3.6-4-277.js (tail -c +5634609 tests/ecmac.db|head -c 719)
 5679	FAIL ch15/15.2/15.2.3/15.2.3.6/15.2.3.6-4-278.js (tail -c +5635329 tests/ecmac.db|head -c 899): [{"message":"Test case returned non-true value!"}]
@@ -6756,8 +6756,8 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 6702	FAIL ch15/15.2/15.2.3/15.2.3.7/15.2.3.7-6-a-260.js (tail -c +6554961 tests/ecmac.db|head -c 1055): [{"message":"Test case returned non-true value!"}]
 6703	FAIL ch15/15.2/15.2.3/15.2.3.7/15.2.3.7-6-a-261.js (tail -c +6556017 tests/ecmac.db|head -c 1029): [{"message":"Test case returned non-true value!"}]
 6704	FAIL ch15/15.2/15.2.3/15.2.3.7/15.2.3.7-6-a-262.js (tail -c +6557047 tests/ecmac.db|head -c 1263): [{"message":"Test case returned non-true value!"}]
-6705	PASS ch15/15.2/15.2.3/15.2.3.7/15.2.3.7-6-a-263.js (tail -c +6558311 tests/ecmac.db|head -c 725)
-6706	FAIL ch15/15.2/15.2.3/15.2.3.7/15.2.3.7-6-a-264.js (tail -c +6559037 tests/ecmac.db|head -c 738): [{"message":"Test case returned non-true value!"}]
+6705	FAIL ch15/15.2/15.2.3/15.2.3.7/15.2.3.7-6-a-263.js (tail -c +6558311 tests/ecmac.db|head -c 725): [{"message":"Test case returned non-true value!"}]
+6706	PASS ch15/15.2/15.2.3/15.2.3.7/15.2.3.7-6-a-264.js (tail -c +6559037 tests/ecmac.db|head -c 738)
 6707	PASS ch15/15.2/15.2.3/15.2.3.7/15.2.3.7-6-a-265.js (tail -c +6559776 tests/ecmac.db|head -c 634)
 6708	PASS ch15/15.2/15.2.3/15.2.3.7/15.2.3.7-6-a-266.js (tail -c +6560411 tests/ecmac.db|head -c 773)
 6709	FAIL ch15/15.2/15.2.3/15.2.3.7/15.2.3.7-6-a-267.js (tail -c +6561185 tests/ecmac.db|head -c 957): [{"message":"Test case returned non-true value!"}]
@@ -7526,7 +7526,7 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 7472	FAIL ch15/15.4/15.4.4/15.4.4.11/S15.4.4.11_A4_T2.js (tail -c +7125859 tests/ecmac.db|head -c 1510): [{"message":"cannot read property 'sort' of undefined"}]
 7473	FAIL ch15/15.4/15.4.4/15.4.4.11/S15.4.4.11_A4_T3.js (tail -c +7127370 tests/ecmac.db|head -c 1439): [{"message":"cannot read property 'sort' of undefined"}]
 7474	FAIL ch15/15.4/15.4.4/15.4.4.11/S15.4.4.11_A5_T1.js (tail -c +7128810 tests/ecmac.db|head -c 486): [{"message":"#1.2: Array.sort should not eat exceptions"}]
-7475	FAIL ch15/15.4/15.4.4/15.4.4.11/S15.4.4.11_A6_T2.js (tail -c +7129297 tests/ecmac.db|head -c 2069): [{"message":"#1: Array.prototype[1] = -1; x = [1,0]; x.length = 2; x.sort(); x[0] === 0. Actual: -0"}]
+7475	FAIL ch15/15.4/15.4.4/15.4.4.11/S15.4.4.11_A6_T2.js (tail -c +7129297 tests/ecmac.db|head -c 2069): [{"message":"#3: Array.prototype[1] = -1; x = [1,0]; x.length = 2; x.sort(); x.length = 0; x[0] === undefined. Actual: 0"}]
 7476	FAIL ch15/15.4/15.4.4/15.4.4.11/S15.4.4.11_A7.1.js (tail -c +7131367 tests/ecmac.db|head -c 721): [{"message":"cannot read property 'sort' of undefined"}]
 7477	FAIL ch15/15.4/15.4.4/15.4.4.11/S15.4.4.11_A7.2.js (tail -c +7132089 tests/ecmac.db|head -c 902): [{"message":"cannot read property 'sort' of undefined"}]
 7478	FAIL ch15/15.4/15.4.4/15.4.4.11/S15.4.4.11_A7.3.js (tail -c +7132992 tests/ecmac.db|head -c 550): [{"message":"cannot read property 'sort' of undefined"}]
@@ -9600,7 +9600,7 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 9546	PASS ch15/15.4/15.4.4/15.4.4.5/S15.4.4.5_A6.5.js (tail -c +8638824 tests/ecmac.db|head -c 653)
 9547	FAIL ch15/15.4/15.4.4/15.4.4.5/S15.4.4.5_A6.6.js (tail -c +8639478 tests/ecmac.db|head -c 411): [{"message":"cannot read property 'join' of undefined"}]
 9548	PASS ch15/15.4/15.4.4/15.4.4.5/S15.4.4.5_A6.7.js (tail -c +8639890 tests/ecmac.db|head -c 589)
-9549	FAIL ch15/15.4/15.4.4/15.4.4.6/S15.4.4.6_A1.1_T1.js (tail -c +8640480 tests/ecmac.db|head -c 895): [{"message":"#2: var x = Array(1,2,3); x.length = 0; x.pop() === undefined. Actual: 0"}]
+9549	FAIL ch15/15.4/15.4.4/15.4.4.6/S15.4.4.6_A1.1_T1.js (tail -c +8640480 tests/ecmac.db|head -c 895): [{"message":"#2: var x = Array(1,2,3); x.length = 0; x.pop() === undefined. Actual: 3"}]
 9550	FAIL ch15/15.4/15.4.4/15.4.4.6/S15.4.4.6_A1.2_T1.js (tail -c +8641376 tests/ecmac.db|head -c 1498): [{"message":"#6: x = []; x[0] = 0; x[3] = 3; x.pop(); x.length == 3"}]
 9551	FAIL ch15/15.4/15.4.4/15.4.4.6/S15.4.4.6_A2_T1.js (tail -c +8642875 tests/ecmac.db|head -c 1658): [{"message":"cannot read property 'pop' of undefined"}]
 9552	FAIL ch15/15.4/15.4.4/15.4.4.6/S15.4.4.6_A2_T2.js (tail -c +8644534 tests/ecmac.db|head -c 3004): [{"message":"cannot read property 'pop' of undefined"}]
@@ -9609,8 +9609,8 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 9555	FAIL ch15/15.4/15.4.4/15.4.4.6/S15.4.4.6_A3_T1.js (tail -c +8652166 tests/ecmac.db|head -c 1203): [{"message":"cannot read property 'pop' of undefined"}]
 9556	FAIL ch15/15.4/15.4.4/15.4.4.6/S15.4.4.6_A3_T2.js (tail -c +8653370 tests/ecmac.db|head -c 1201): [{"message":"cannot read property 'pop' of undefined"}]
 9557	FAIL ch15/15.4/15.4.4/15.4.4.6/S15.4.4.6_A3_T3.js (tail -c +8654572 tests/ecmac.db|head -c 916): [{"message":"cannot read property 'pop' of undefined"}]
-9558	FAIL ch15/15.4/15.4.4/15.4.4.6/S15.4.4.6_A4_T1.js (tail -c +8655489 tests/ecmac.db|head -c 1624): [{"message":"#1: Array.prototype[1] = 1; x = [0]; x.length = 2; x.pop() === 1. Actual: 2"}]
-9559	FAIL ch15/15.4/15.4.4/15.4.4.6/S15.4.4.6_A4_T2.js (tail -c +8657114 tests/ecmac.db|head -c 1662): [{"message":"#1: Array.prototype[1] = -1; x = [0,1]; x.length = 2; x.pop() === 1. Actual: 2"}]
+9558	FAIL ch15/15.4/15.4.4/15.4.4.6/S15.4.4.6_A4_T1.js (tail -c +8655489 tests/ecmac.db|head -c 1624): [{"message":"#1: Array.prototype[1] = 1; x = [0]; x.length = 2; x.pop() === 1. Actual: 0"}]
+9559	FAIL ch15/15.4/15.4.4/15.4.4.6/S15.4.4.6_A4_T2.js (tail -c +8657114 tests/ecmac.db|head -c 1662): [{"message":"#2: Array.prototype[1] = -1; x = [0,1]; x.length = 2; x.pop(); x[1] === -1. Actual: undefined"}]
 9560	FAIL ch15/15.4/15.4.4/15.4.4.6/S15.4.4.6_A5.1.js (tail -c +8658777 tests/ecmac.db|head -c 713): [{"message":"cannot read property 'pop' of undefined"}]
 9561	FAIL ch15/15.4/15.4.4/15.4.4.6/S15.4.4.6_A5.2.js (tail -c +8659491 tests/ecmac.db|head -c 888): [{"message":"cannot read property 'pop' of undefined"}]
 9562	FAIL ch15/15.4/15.4.4/15.4.4.6/S15.4.4.6_A5.3.js (tail -c +8660380 tests/ecmac.db|head -c 549): [{"message":"cannot read property 'pop' of undefined"}]
@@ -9643,8 +9643,8 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 9589	FAIL ch15/15.4/15.4.4/15.4.4.8/S15.4.4.8_A3_T1.js (tail -c +8714122 tests/ecmac.db|head -c 1221): [{"message":"cannot read property 'reverse' of undefined"}]
 9590	FAIL ch15/15.4/15.4.4/15.4.4.8/S15.4.4.8_A3_T2.js (tail -c +8715344 tests/ecmac.db|head -c 1582): [{"message":"cannot read property 'reverse' of undefined"}]
 9591	FAIL ch15/15.4/15.4.4/15.4.4.8/S15.4.4.8_A3_T3.js (tail -c +8716927 tests/ecmac.db|head -c 1511): [{"message":"cannot read property 'reverse' of undefined"}]
-9592	FAIL ch15/15.4/15.4.4/15.4.4.8/S15.4.4.8_A4_T1.js (tail -c +8718439 tests/ecmac.db|head -c 2083): [{"message":"#1: Array.prototype[1] = 1; x = [0]; x.length = 2; x.reverse(); x[0] === 1. Actual: -0"}]
-9593	FAIL ch15/15.4/15.4.4/15.4.4.8/S15.4.4.8_A4_T2.js (tail -c +8720523 tests/ecmac.db|head -c 2127): [{"message":"#1: Array.prototype[1] = -1; x = [0,1]; x.length = 2; x.reverse(); x[0] === 1. Actual: -0"}]
+9592	FAIL ch15/15.4/15.4.4/15.4.4.8/S15.4.4.8_A4_T1.js (tail -c +8718439 tests/ecmac.db|head -c 2083): [{"message":"#1: Array.prototype[1] = 1; x = [0]; x.length = 2; x.reverse(); x[0] === 1. Actual: 0"}]
+9593	FAIL ch15/15.4/15.4.4/15.4.4.8/S15.4.4.8_A4_T2.js (tail -c +8720523 tests/ecmac.db|head -c 2127): [{"message":"#3: Array.prototype[1] = -1; x = [0,1]; x.length = 2; x.reverse(); x.length = 0; x[0] === undefined. Actual: 1"}]
 9594	FAIL ch15/15.4/15.4.4/15.4.4.8/S15.4.4.8_A5.1.js (tail -c +8722651 tests/ecmac.db|head -c 737): [{"message":"cannot read property 'reverse' of undefined"}]
 9595	FAIL ch15/15.4/15.4.4/15.4.4.8/S15.4.4.8_A5.2.js (tail -c +8723389 tests/ecmac.db|head -c 936): [{"message":"cannot read property 'reverse' of undefined"}]
 9596	FAIL ch15/15.4/15.4.4/15.4.4.8/S15.4.4.8_A5.3.js (tail -c +8724326 tests/ecmac.db|head -c 581): [{"message":"cannot read property 'reverse' of undefined"}]
@@ -9674,7 +9674,7 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 9620	FAIL ch15/15.4/15.4.5/15.4.5-1.js (tail -c +8753104 tests/ecmac.db|head -c 351): [{"message":"value is not a function"}]
 9621	FAIL ch15/15.4/15.4.5/15.4.5.1/15.4.5.1-3.d-1.js (tail -c +8753456 tests/ecmac.db|head -c 389): [{"message":"Test case returned non-true value!"}]
 9622	FAIL ch15/15.4/15.4.5/15.4.5.1/15.4.5.1-3.d-2.js (tail -c +8753846 tests/ecmac.db|head -c 391): [{"message":"Test case returned non-true value!"}]
-9623	PASS ch15/15.4/15.4.5/15.4.5.1/15.4.5.1-3.d-3.js (tail -c +8754238 tests/ecmac.db|head -c 341)
+9623	FAIL ch15/15.4/15.4.5/15.4.5.1/15.4.5.1-3.d-3.js (tail -c +8754238 tests/ecmac.db|head -c 341): [{"message":"Test case returned non-true value!"}]
 9624	PASS ch15/15.4/15.4.5/15.4.5.1/15.4.5.1-5-1.js (tail -c +8754580 tests/ecmac.db|head -c 382)
 9625	FAIL ch15/15.4/15.4.5/15.4.5.1/15.4.5.1-5-2.js (tail -c +8754963 tests/ecmac.db|head -c 372): [{"message":"Test case returned non-true value!"}]
 9626	FAIL ch15/15.4/15.4.5/15.4.5.1/S15.4.5.1_A1.1_T1.js (tail -c +8755336 tests/ecmac.db|head -c 1125): [{"message":"[RangeError] is not defined"}]
@@ -9682,17 +9682,17 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 9628	FAIL ch15/15.4/15.4.5/15.4.5.1/S15.4.5.1_A1.2_T1.js (tail -c +8758018 tests/ecmac.db|head -c 838): [{"message":"#1: x = [0,,2,,4]; x.length = 4; x[4] === undefined. Actual: 4"}]
 9629	FAIL ch15/15.4/15.4.5/15.4.5.1/S15.4.5.1_A1.2_T2.js (tail -c +8758857 tests/ecmac.db|head -c 716): [{"message":"#2: Array.prototype[2] = -1; x = [0,1,3]; x.length = 2; x[2] === -1. Actual: 2"}]
 9630	FAIL ch15/15.4/15.4.5/15.4.5.1/S15.4.5.1_A1.2_T3.js (tail -c +8759574 tests/ecmac.db|head -c 808): [{"message":"#2: Array.prototype[2] = 2; x = [0,1]; x.length = 3; x.length = 2; x[2] === 2. Actual: undefined"}]
-9631	FAIL ch15/15.4/15.4.5/15.4.5.1/S15.4.5.1_A1.3_T1.js (tail -c +8760383 tests/ecmac.db|head -c 1183): [{"message":"#1: x = []; x.length = true; x.length === 1. Actual: true"}]
-9632	FAIL ch15/15.4/15.4.5/15.4.5.1/S15.4.5.1_A1.3_T2.js (tail -c +8761567 tests/ecmac.db|head -c 3045): [{"message":"#1: x = []; x.length = {valueOf: function() {return 2}};  x.length === 2. Actual: 2"}]
+9631	FAIL ch15/15.4/15.4.5/15.4.5.1/S15.4.5.1_A1.3_T1.js (tail -c +8760383 tests/ecmac.db|head -c 1183): [{"message":"#1: x = []; x.length = true; x.length === 1. Actual: 0"}]
+9632	FAIL ch15/15.4/15.4.5/15.4.5.1/S15.4.5.1_A1.3_T2.js (tail -c +8761567 tests/ecmac.db|head -c 3045): [{"message":"#1: x = []; x.length = {valueOf: function() {return 2}};  x.length === 2. Actual: 0"}]
 9633	FAIL ch15/15.4/15.4.5/15.4.5.1/S15.4.5.1_A2.1_T1.js (tail -c +8764613 tests/ecmac.db|head -c 1061): [{"message":"#1.1: x = []; x[4294967295] = 1; x.length === 0. Actual: 5"}]
 9634	FAIL ch15/15.4/15.4.5/15.4.5.1/S15.4.5.1_A2.2_T1.js (tail -c +8765675 tests/ecmac.db|head -c 726): [{"message":"#1: x = Array(100); x[0] = 1; x.length === 100. Actual: 1"}]
 9635	PASS ch15/15.4/15.4.5/15.4.5.1/S15.4.5.1_A2.3_T1.js (tail -c +8766402 tests/ecmac.db|head -c 600)
 9636	FAIL ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A1_T1.js (tail -c +8767003 tests/ecmac.db|head -c 1149): [{"message":"#4: x = []; x[0] = 1; x[1] = 1; x[2147483648] = 1; x.length === 2147483649. Actual: 3"}]
 9637	FAIL ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A1_T2.js (tail -c +8768153 tests/ecmac.db|head -c 731): [{"message":"#1: x = []; x[4294967295] = 1; x.length === 0. Actual: 5"}]
 9638	PASS ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A2_T1.js (tail -c +8768885 tests/ecmac.db|head -c 778)
-9639	PASS ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A3_T1.js (tail -c +8769664 tests/ecmac.db|head -c 810)
-9640	FAIL ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A3_T2.js (tail -c +8770475 tests/ecmac.db|head -c 1508): [{"message":"#2: x = []; x[1] = 1; x[3] = 3; x[5] = 5; x.length = 4; x[5] === undefined. Actual: 5"}]
-9641	FAIL ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A3_T3.js (tail -c +8771984 tests/ecmac.db|head -c 795): [{"message":"[RangeError] is not defined"}]
+9639	FAIL ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A3_T1.js (tail -c +8769664 tests/ecmac.db|head -c 810): [{"message":"#1: x = []; x.length = 1; x.length === 1. Actual: 0"}]
+9640	FAIL ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A3_T2.js (tail -c +8770475 tests/ecmac.db|head -c 1508): [{"message":"#1: x = []; x[1] = 1; x[3] = 3; x[5] = 5; x.length = 4; x.length === 4. Actual: 6"}]
+9641	FAIL ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A3_T3.js (tail -c +8771984 tests/ecmac.db|head -c 795): [{"message":"#1: x = []; x.length = 4294967295; x.length === 4294967295"}]
 9642	FAIL ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A3_T4.js (tail -c +8772780 tests/ecmac.db|head -c 1074): [{"message":"#3: x = [0,1,2]; x[4294967294] = 4294967294; x.length = 2; x[2] === undefined. Actual: 2"}]
 9643	FAIL ch15/15.5/15.5.1/S15.5.1.1_A1_T1.js (tail -c +8773855 tests/ecmac.db|head -c 922): [{"message":"#2: __str = String(function(){}()); __str === "undefined". Actual: __str ==="}]
 9644	PASS ch15/15.5/15.5.1/S15.5.1.1_A1_T10.js (tail -c +8774778 tests/ecmac.db|head -c 1477)

--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -1323,6 +1323,8 @@ static const char *test_interpreter(void) {
   ASSERT(check_value(v7, v, "10"));
   ASSERT(v7_exec(v7, &v, "r=0;o={get x() {return 10}, set x(v){r=v}};o.x=10;r") == V7_OK);
   ASSERT(check_value(v7, v, "10"));
+  ASSERT(v7_exec(v7, &v, "g=0;function O() {}; O.prototype = {set x(v) {g=v}};o=new O;o.x=42;[g,Object.keys(o)]") == V7_OK);
+  ASSERT(check_value(v7, v, "[42,[]]"));
 
   ASSERT(v7_exec(v7, &v, "String(new Number(42))") == V7_OK);
   ASSERT(check_value(v7, v, "\"42\""));


### PR DESCRIPTION
When a setter is found in the prototype chain, it should
be invoked. Array `length` property should also have a setter.

This fixes a couple of flacky tests which added an owned
property by assigning `length` to arrays thus breaking our
quicky&dirty array sort/reverse.