### PR TITLE
Add volatile to setjmp result

### DIFF
--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -1195,7 +1195,7 @@ static val_t i_eval_stmt(struct v7 *v7, struct ast *a, ast_off_t *pos,
         char *name;
         size_t name_len;
         ast_off_t saved_pos;
-        enum jmp_type j;
+        volatile enum jmp_type j;
         memcpy(old_jmp, v7->jmp_buf, sizeof(old_jmp));
         name = ast_get_inlined_data(a, *pos, &name_len);
 

--- a/v7.c
+++ b/v7.c
@@ -7835,7 +7835,7 @@ static val_t i_eval_stmt(struct v7 *v7, struct ast *a, ast_off_t *pos,
         char *name;
         size_t name_len;
         ast_off_t saved_pos;
-        enum jmp_type j;
+        volatile enum jmp_type j;
         memcpy(old_jmp, v7->jmp_buf, sizeof(old_jmp));
         name = ast_get_inlined_data(a, *pos, &name_len);
 


### PR DESCRIPTION
I didn't see a test case fail for this, but without it
can potentially lure the optimizer to do something like #244