### PR TITLE
Make MSAN not complain about strings

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -445,7 +445,7 @@ int v7_stringify_value(struct v7 *v7, val_t v, char *buf,
     if (n >= size) {
       n = size - 1;
     }
-    stpncpy(buf, str, n);
+    strncpy(buf, str, n);
     buf[n] = '\0';
     return n;
   } else {


### PR DESCRIPTION
Clang's MSAN was complaining about unitialized memory.
It might caused by a failure to instrument `stpncpy`
since AFAIK the only difference between it and `strncpy`
is the return value which is ignored here.