### PR TITLE
Add make rule to run tests under MSAN

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -5,6 +5,7 @@ unit_test_c11
 unit_test_gcov
 unit_test_valgrind
 unit_test_asan
+unit_test_msan
 *.gcov
 *.gcno
 *.gcda

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -3,7 +3,8 @@ FROM ubuntu:trusty
 MAINTAINER Marko Mikulicic <mkm@cesanta.com>
 
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential libssl-dev
-RUN apt-get install -y --no-install-recommends clang-3.5
+RUN apt-get install -y --no-install-recommends clang-3.5 llvm-3.5
+RUN ln -s /usr/bin/llvm-symbolizer-3.5 /usr/bin/llvm-symbolizer
 
 VOLUME ['/cesanta']
 

--- a/tests/test.mk
+++ b/tests/test.mk
@@ -23,6 +23,7 @@
 # - cpplint:   run the linter
 # - lcov:      generate coverage HTML in test/lcov/index.html
 # - test_asan: run with AddressSanitizer
+# - test_msan: run with MemorySanitizer (linux only)
 # - test_valgrind: run with valgrind
 
 SRC = $(realpath $(PROG).c)
@@ -42,7 +43,7 @@ PEDANTIC=$(shell gcc --version 2>/dev/null | grep -q clang && echo -pedantic)
 # TODO(mkm) fix cxx issues. This file should be the same file used in fossa
 # and we should keep it in sync with subtree or something.
 DIALECTS=cxx ansi c99 c11
-SPECIALS=asan gcov valgrind
+SPECIALS=asan msan gcov valgrind
 
 # Each test target might require either a different compiler name
 # a compiler flag, or a wrapper to be invoked before executing the test
@@ -73,9 +74,15 @@ SOURCES_gcov=$(addprefix $(SRC_DIR)/, $(SOURCES))
 # TODO(mkm): remove once v7 has #lines for amalgamated sources
 SOURCES_asan=$(addprefix $(SRC_DIR)/, $(SOURCES))
 
+# TODO(mkm): remove once v7 has #lines for amalgamated sources
+SOURCES_msan=$(addprefix $(SRC_DIR)/, $(SOURCES))
+
 CC_asan=$(CLANG)
-CFLAGS_asan=-fsanitize=address -fcolor-diagnostics -std=c99
-CMD_asan=ASAN_SYMBOLIZER_PATH=/usr/local/bin/llvm-symbolizer-3.5 ASAN_OPTIONS=allocator_may_return_null=1,symbolize=1 $(CMD)
+CC_msan=$(CC_asan)
+CFLAGS_asan=-fsanitize=address -fcolor-diagnostics -fno-common -std=c99
+CFLAGS_msan=-fsanitize=memory -fcolor-diagnostics -fno-common -std=c99
+CMD_asan=ASAN_SYMBOLIZER_PATH=/usr/local/bin/llvm-symbolizer-3.5 ASAN_OPTIONS=allocator_may_return_null=1,symbolize=1,detect_stack_use_after_return=1,strict_init_order=1 $(CMD)
+CMD_msan=$(CMD_asan)
 
 CMD_valgrind=valgrind
 
@@ -132,7 +139,7 @@ cpplint:
 
 clean: clean_coverage
 	@echo -e "CLEAN\tall"
-	@rm -rf $(PROG) $(PROG)_ansi $(PROG)_c99 $(PROG)_gcov $(PROG)_asan $(PROG)_cxx $(PROG)_valgrind lcov.info *.txt *.exe *.obj *.o a.out *.pdb *.opt
+	@rm -rf $(PROG) $(PROG)_ansi $(PROG)_c99 $(PROG)_gcov $(PROG)_asan $(PROG)_msan $(PROG)_cxx $(PROG)_valgrind lcov.info *.txt *.exe *.obj *.o a.out *.pdb *.opt
 
 clean_coverage:
 	@echo -e "CLEAN\tcoverage"


### PR DESCRIPTION
MSAN currently only supports linux,
The docker image hence needs the llvm-symbolizer tool.