### PR TITLE
Fix uninitialized memory access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,11 @@ v7: $(TOP_HEADERS) $(TOP_SOURCES) v7.h
 #	$(CC) $(TOP_SOURCES) -o $@ -DV7_EXE $(CFLAGS) -lm
 
 asan_v7:
-	@$(CLANG) -fsanitize=address -fcolor-diagnostics $(TOP_SOURCES) -o v7 -DV7_EXE -DV7_EXPOSE_PRIVATE $(CFLAGS) -lm
+	@$(CLANG) -fsanitize=address -fcolor-diagnostics -fno-common $(TOP_SOURCES) -o v7 -DV7_EXE -DV7_EXPOSE_PRIVATE $(CFLAGS) -lm
+	@ASAN_SYMBOLIZER_PATH=/usr/local/bin/llvm-symbolizer-3.5 ASAN_OPTIONS=symbolize=1,detect_stack_use_after_return=1,strict_init_order=1 ./v7 $(V7_ARGS)
+
+msan_v7:
+	@$(CLANG) -fsanitize=memory -fcolor-diagnostics -fno-common -fsanitize-memory-track-origins $(TOP_SOURCES) -o v7 -DV7_EXE -DV7_EXPOSE_PRIVATE $(CFLAGS) -lm
 	@ASAN_SYMBOLIZER_PATH=/usr/local/bin/llvm-symbolizer-3.5 ASAN_OPTIONS=symbolize=1 ./v7 $(V7_ARGS)
 
 amalgamated_v7: v7.h v7.c

--- a/src/array.c
+++ b/src/array.c
@@ -84,7 +84,7 @@ static int a_partition(val_t *a, int l, int r, void *user_data) {
   int i = l, j = r + 1;
 
   for (;;) {
-    do ++i; while (a_cmp(user_data, &a[i], &pivot) <= 0 && i <= r);
+    do ++i; while (i <= r && a_cmp(user_data, &a[i], &pivot) <= 0);
     do --j; while (a_cmp(user_data, &a[j], &pivot) > 0);
     if (i >= j) break;
     t = a[i]; a[i] = a[j]; a[j] = t;

--- a/src/internal.h
+++ b/src/internal.h
@@ -38,7 +38,6 @@
 typedef unsigned __int64 uint64_t;
 typedef unsigned int uint32_t;
 typedef unsigned char uint8_t;
-char *stpncpy(char *, const char *, size_t);
 #else
 #include <stdint.h>
 #endif

--- a/src/slre.c
+++ b/src/slre.c
@@ -1089,6 +1089,7 @@ int slre_compile(const char *pat, size_t pat_len, const char *flags,
   e.prog = (struct slre_prog *) SLRE_MALLOC(sizeof(struct slre_prog));
   e.pstart = e.pend = (struct slre_node *)
              SLRE_MALLOC(sizeof(struct slre_node) * pat_len * 2);
+  e.prog->flags = 0;
 
   if ((err_code = setjmp(e.jmp_buf)) != SLRE_OK) {
     SLRE_FREE(e.pstart);
@@ -1187,6 +1188,7 @@ static unsigned char re_match(struct slre_instruction *pc, const char *start,
   unsigned short thr_num = 1;
   unsigned char thr;
   size_t i, off = 0;
+  const char *base = start;
 
   /* queue initial thread */
   re_newthread(threads, pc, start, loot);
@@ -1203,7 +1205,7 @@ static unsigned char re_match(struct slre_instruction *pc, const char *start,
           return 1;
         case I_ANY:
         case I_ANYNL:
-          c = re_getrune(start, len, &off);
+          c = re_getrune(start, base + len - start, &off);
           if (!c || (pc->opcode == I_ANY && isnewline(c))) RE_NO_MATCH();
           break;
 

--- a/src/string.c
+++ b/src/string.c
@@ -437,11 +437,12 @@ static val_t Str_length(struct v7 *v7, val_t this_obj, val_t args) {
 
 V7_PRIVATE long arg_long(struct v7 *v7, val_t args, int n, long default_value) {
   char buf[40];
+  size_t l;
   val_t arg_n = i_value_of(v7, v7_array_at(v7, args, n));
   if (v7_is_double(arg_n)) return (long) v7_to_double(arg_n);
   if (arg_n == V7_NULL) return 0;
-  to_str(v7, arg_n, buf, sizeof(buf), 0);
-  if (isdigit(buf[0])) return strtol(buf, NULL, 10);
+  l = to_str(v7, arg_n, buf, sizeof(buf), 0);
+  if (l > 0 && isdigit(buf[0])) return strtol(buf, NULL, 10);
   return default_value;
 }
 
@@ -495,7 +496,10 @@ static val_t Str_split(struct v7 *v7, val_t this_obj, val_t args) {
       }
     }
     if (j < i && n2 > 0) {
-      v7_array_append(v7, res, v7_create_string(v7, s1 + j, i - j, 1));
+      char *tmp = (char *) malloc(i - j - 1);
+      memcpy(tmp, s1 + j, i - j - 1);
+      v7_array_append(v7, res, v7_create_string(v7, tmp, i - j - 1, 1));
+      free(tmp);
     }
   }
 

--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -1368,10 +1368,14 @@ static const char *test_interpreter(void) {
   ASSERT(v7_exec(v7, &v, "'' && {}") == V7_OK);
   ASSERT(check_value(v7, v, "\"\""));
 
+  /* here temporarily because test_stdlib has memory violations */
+  ASSERT(v7_exec(v7, &v, "a=[2,1];a.sort();a") == V7_OK);
+  ASSERT(check_value(v7, v, "[1,2]"));
+
   /* check execution failure caused by bad parsing */
   ASSERT(v7_exec(v7, &v, "function") == V7_SYNTAX_ERROR);
   return NULL;
-}
+} /* test_interpreter */
 
 static const char *test_strings(void) {
   val_t s = 0;

--- a/v7.c
+++ b/v7.c
@@ -3402,7 +3402,7 @@ static int a_partition(val_t *a, int l, int r, void *user_data) {
   int i = l, j = r + 1;
 
   for (;;) {
-    do ++i; while (a_cmp(user_data, &a[i], &pivot) <= 0 && i <= r);
+    do ++i; while (i <= r && a_cmp(user_data, &a[i], &pivot) <= 0);
     do --j; while (a_cmp(user_data, &a[j], &pivot) > 0);
     if (i >= j) break;
     t = a[i]; a[i] = a[j]; a[j] = t;
@@ -5266,7 +5266,7 @@ int v7_stringify_value(struct v7 *v7, val_t v, char *buf,
     if (n >= size) {
       n = size - 1;
     }
-    stpncpy(buf, str, n);
+    strncpy(buf, str, n);
     buf[n] = '\0';
     return n;
   } else {


### PR DESCRIPTION
- Fix incestuous string insertion in Str_split and added comment
- Fix arg_long with zero length strings
- Fix bounds in SLRE
- Initialize flags in SLRE.

MSAN also doesn't instrument correctly stpncpy so changing with strncpy.

DIFFBASE=#0x100