### PR TITLE
Fix Function ctor mem use after return

### DIFF
--- a/src/function.c
+++ b/src/function.c
@@ -17,7 +17,7 @@ static val_t Function_ctor(struct v7 *v7, val_t this_obj, val_t args) {
   if (num_args <= 0) return res;
 
   /* TODO(lsm): Constructing function source code here. Optimize this. */
-  n += snprintf(buf + n, sizeof(buf) - n, "%s", "var ___fUn = function(");
+  n += snprintf(buf + n, sizeof(buf) - n, "%s", "(function(");
 
   for (i = 0; i < num_args - 1; i++) {
     param = i_value_of(v7, v7_array_at(v7, args, i));
@@ -35,7 +35,7 @@ static val_t Function_ctor(struct v7 *v7, val_t this_obj, val_t args) {
     s = v7_to_string(v7, &body, &size);
     n += snprintf(buf + n, sizeof(buf) - n, "%.*s", (int) size, s);
   }
-  n += snprintf(buf + n, sizeof(buf) - n, "%s", "}");
+  n += snprintf(buf + n, sizeof(buf) - n, "%s", "})");
 
   if (v7_exec_with(v7, &res, buf, V7_UNDEFINED) != V7_OK) {
     throw_exception(v7, "SyntaxError", "Invalid function body");

--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -293,7 +293,7 @@ static const char *test_stdlib(void) {
 
   /* Date() tests interact with external object (local date & time), so
       if host have strange date/time setting it won't be work */
-  
+
 #if 0
   /* Date */
   tzset();
@@ -500,7 +500,7 @@ static const char *test_stdlib(void) {
   ASSERT(v7_exec(v7, &v, "Date.parse(\"10/15/2015 12:30 GMT\")") == V7_OK);
   ASSERT(check_num(v, 1444912200000));
 #endif
-  
+
 #if 0
   /* Regexp */
   ASSERT(v7_exec(v7, &v, "re = /GET (\\S+) HTTP/; re")) != NULL);

--- a/v7.c
+++ b/v7.c
@@ -11731,7 +11731,7 @@ static val_t Function_ctor(struct v7 *v7, val_t this_obj, val_t args) {
   if (num_args <= 0) return res;
 
   /* TODO(lsm): Constructing function source code here. Optimize this. */
-  n += snprintf(buf + n, sizeof(buf) - n, "%s", "var ___fUn = function(");
+  n += snprintf(buf + n, sizeof(buf) - n, "%s", "(function(");
 
   for (i = 0; i < num_args - 1; i++) {
     param = i_value_of(v7, v7_array_at(v7, args, i));
@@ -11749,7 +11749,7 @@ static val_t Function_ctor(struct v7 *v7, val_t this_obj, val_t args) {
     s = v7_to_string(v7, &body, &size);
     n += snprintf(buf + n, sizeof(buf) - n, "%.*s", (int) size, s);
   }
-  n += snprintf(buf + n, sizeof(buf) - n, "%s", "}");
+  n += snprintf(buf + n, sizeof(buf) - n, "%s", "})");
 
   if (v7_exec_with(v7, &res, buf, V7_UNDEFINED) != V7_OK) {
     throw_exception(v7, "SyntaxError", "Invalid function body");


### PR DESCRIPTION
Not sure exactly which pointer to the stack buffer is kept
but it looks like avoiding the var works around it.

TODO(mkm) investigate