### PR TITLE
Fix date parsing and avoid using `%03*s`

### DIFF
--- a/src/date.c
+++ b/src/date.c
@@ -368,10 +368,11 @@ static int d_parsedatestr(const char *jstr, size_t len, struct timeparts *tp,
   /* trying toString()/toUTCString()/toDateFormat() formats */
   {
     char month[4];
-    const char *frmString = " %03*s %03s %02d %d %02d:%02d:%02d %03s%d";
-    res = sscanf(str, frmString, month, &tp->day, &tp->year,
+    int dowlen;
+    const char *frmString = " %*s%n %03s %02d %d %02d:%02d:%02d %03s%d";
+    res = sscanf(str, frmString, &dowlen, month, &tp->day, &tp->year,
                  &tp->hour, &tp->min, &tp->sec, gmt, tz);
-    if (res == 3 || (res >= 6 && res <= 8)) {
+    if (dowlen == 3 && (res == 3 || (res >= 6 && res <= 8))) {
       if ((tp->month = d_getnumbyname(mon_name,
                                       ARRAY_SIZE(mon_name), month)) != -1) {
         if (res == 7 && strncmp(gmt, "GMT", 3) == 0) {

--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -294,6 +294,11 @@ static const char *test_stdlib(void) {
   /* Date() tests interact with external object (local date & time), so
       if host have strange date/time setting it won't be work */
 
+  ASSERT(v7_exec(v7, &v, "Number(new Date('IncDec 01 2015 00:00:00'))") == V7_OK);
+  ASSERT(check_value(v7, v, "NaN"));
+  ASSERT(v7_exec(v7, &v, "Number(new Date('My Jul 01 2015 00:00:00'))") == V7_OK);
+  ASSERT(check_value(v7, v, "NaN"));
+
 #if 0
   /* Date */
   tzset();

--- a/v7.c
+++ b/v7.c
@@ -11156,10 +11156,11 @@ static int d_parsedatestr(const char *jstr, size_t len, struct timeparts *tp,
   /* trying toString()/toUTCString()/toDateFormat() formats */
   {
     char month[4];
-    const char *frmString = " %03*s %03s %02d %d %02d:%02d:%02d %03s%d";
-    res = sscanf(str, frmString, month, &tp->day, &tp->year,
+    int dowlen;
+    const char *frmString = " %*s%n %03s %02d %d %02d:%02d:%02d %03s%d";
+    res = sscanf(str, frmString, &dowlen, month, &tp->day, &tp->year,
                  &tp->hour, &tp->min, &tp->sec, gmt, tz);
-    if (res == 3 || (res >= 6 && res <= 8)) {
+    if (dowlen == 3 && (res == 3 || (res >= 6 && res <= 8))) {
       if ((tp->month = d_getnumbyname(mon_name,
                                       ARRAY_SIZE(mon_name), month)) != -1) {
         if (res == 7 && strncmp(gmt, "GMT", 3) == 0) {


### PR DESCRIPTION
Clang ASAN was issuing runtime warnings that the `%03*s` format
is not supported. The OSX C library's implementation does support it
though, but it might not be portable.

Furthermore, this solution fixes a couple of illegal inputs that were
previously accepted erroneously:

- `IncDec 01 2015 00:00:00`
- `My Jul 01 2015 00:00:00`

---

@alashkin, I'd like you to review this small change. Thanks.