### PR TITLE
Add v7_apply args to GC rootset

### DIFF
--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -1384,6 +1384,13 @@ val_t v7_apply(struct v7 *v7, val_t f, val_t this_object, val_t args) {
   tmp_stack_push(&vf, &res);
   tmp_stack_push(&vf, &arguments);
   tmp_stack_push(&vf, &saved_this);
+  /*
+   * Since v7_apply can be called from user code
+   * we have to treat all arguments as roots.
+   */
+  tmp_stack_push(&vf, &args);
+  tmp_stack_push(&vf, &f);
+  tmp_stack_push(&vf, &this_object);
 
   if (v7_is_cfunction(f)) {
     return v7_to_cfunction(f)(v7, this_object, args);

--- a/v7.c
+++ b/v7.c
@@ -8544,6 +8544,7 @@ val_t v7_apply(struct v7 *v7, val_t f, val_t this_object, val_t args) {
   tmp_stack_push(&vf, &res);
   tmp_stack_push(&vf, &arguments);
   tmp_stack_push(&vf, &saved_this);
+  tmp_stack_push(&vf, &args);
 
   if (v7_is_cfunction(f)) {
     return v7_to_cfunction(f)(v7, this_object, args);


### PR DESCRIPTION
v7_apply can be invoked from user/builtin C code.
Usually the argument array will be a temporary object
and hence the GC will free it.
It's unreasonable to force all call sites to add the
argument array to the tmp_stack.

---

Hi @cpq,

Please review my micronian change. Thanks.

This fixes the issue you found in #291