### PR TITLE
Restore build on MSVC6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,16 +58,9 @@ amalgamated_v7: v7.h v7.c
 m32_v7: $(TOP_HEADERS) $(TOP_SOURCES) v7.h
 	$(CC) $(TOP_SOURCES) -o v7 -DV7_EXE -DV7_EXPOSE_PRIVATE $(CFLAGS) -m32 -lm
 
-js: v7
-	@./v7 tests/v7_basic_test.js
-	@rhino -version 130 tests/v7_basic_test.js
-
-t: v7
-	./v7 tests/run_ecma262_tests.js
-
 w: v7.c
+	wine cl v7.c /Zi -DV7_EXE -DV7_EXPOSE_PRIVATE
 	wine cl tests/unit_test.c $(TOP_SOURCES) $(V7_FLAGS) /Zi -DV7_EXPOSE_PRIVATE
-	wine unit_test.exe
 
 clean:
 	@$(MAKE) -C tests clean

--- a/src/ast.h
+++ b/src/ast.h
@@ -137,10 +137,10 @@ typedef unsigned long ast_off_t;
 
 struct ast_node_def {
   const char *name;      /* tag name, for debugging and serialization */
-  uint8_t has_varint;    /* has a varint body */
-  uint8_t has_inlined;   /* inlined data whose size is in the varint field */
-  uint8_t num_skips;     /* number of skips */
-  uint8_t num_subtrees;  /* number of fixed subtrees */
+  unsigned char has_varint;    /* has a varint body */
+  unsigned char has_inlined;   /* inlined data whose size is in the varint field */
+  unsigned char num_skips;     /* number of skips */
+  unsigned char num_subtrees;  /* number of fixed subtrees */
 };
 extern const struct ast_node_def ast_node_defs[];
 

--- a/src/date.c
+++ b/src/date.c
@@ -4,14 +4,6 @@
  */
 
 #include "internal.h"
-#include <sys/time.h>
-#include <time.h>
-#include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <locale.h>
-#include <stddef.h>
 
 #ifdef __APPLE__
 int64_t strtoll(const char *, char **, int);
@@ -228,10 +220,8 @@ struct timeparts {
 
 /*+++ this functions is used to get current date/time & timezone */
 
-static void d_gettime(etime_t *time) {
-  struct timeval tv;
-  gettimeofday(&tv, NULL);
-  *time = (etime_t) tv.tv_sec * 1000 + (etime_t) tv.tv_usec / 1000;
+static void d_gettime(etime_t *t) {
+  *t = time(NULL);
 }
 
 static const char *d_gettzname() {

--- a/src/gc.c
+++ b/src/gc.c
@@ -172,8 +172,8 @@ V7_PRIVATE void gc_mark(struct v7 *v7, val_t v) {
 
 static void gc_dump_arena_stats(const char *msg, struct gc_arena *a) {
   if (a->verbose) {
-    fprintf(stderr, "%s: total allocations %lu, max %lu, alive %u\n", msg,
-            (unsigned long) a->allocations, a->size, a->alive);
+    fprintf(stderr, "%s: total allocations %lu, max %lu, alive %lu\n", msg,
+            a->allocations, a->size, a->alive);
   }
 }
 

--- a/src/gc.h
+++ b/src/gc.h
@@ -9,7 +9,6 @@
 #include "internal.h"
 #include "vm.h"
 
-
 /* Disable GC on 32-bit platform for now */
 #if ULONG_MAX == 4294967295
 #define V7_DISABLE_GC
@@ -28,8 +27,12 @@ struct gc_cell {
   uintptr_t word;
 };
 
+#ifdef _WIN32
+#define GC_TMP_FRAME(v) struct gc_tmp_frame v = new_tmp_frame(v7);
+#else
 #define GC_TMP_FRAME(v) __attribute__((cleanup(tmp_frame_cleanup), unused)) \
   struct gc_tmp_frame v = new_tmp_frame(v7);
+#endif
 
 #if defined(__cplusplus)
 extern "C" {

--- a/src/internal.h
+++ b/src/internal.h
@@ -21,6 +21,7 @@
 #include <errno.h>
 #include <float.h>
 #include <limits.h>
+#include <locale.h>
 #include <math.h>
 #include <stdarg.h>
 #include <stddef.h>
@@ -28,6 +29,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <setjmp.h>
+#include <time.h>
 
 #ifdef _WIN32
 #define vsnprintf _vsnprintf
@@ -35,10 +37,15 @@
 #define isnan(x) _isnan(x)
 #define isinf(x) (!_finite(x))
 #define __unused
-typedef unsigned __int64 uint64_t;
+typedef __int64 int64_t;
+typedef int int32_t;
 typedef unsigned int uint32_t;
+typedef unsigned short uint16_t;
 typedef unsigned char uint8_t;
+typedef unsigned long uintptr_t;
+#define __func__ ""
 #else
+#include <sys/time.h>
 #include <stdint.h>
 #endif
 

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -153,6 +153,12 @@ static double i_int_bin_op(struct v7 *v7, enum ast_tag tag, double a,
   }
 }
 
+#ifdef _WIN32
+static int signbit(double x) {
+  return x > 0;
+}
+#endif
+
 static double i_num_bin_op(struct v7 *v7, enum ast_tag tag, double a,
                            double b) {
   switch (tag) {

--- a/src/math.c
+++ b/src/math.c
@@ -22,6 +22,12 @@ V7_PRIVATE val_t Math_##name(struct v7 *v7, val_t this_obj, val_t args) {   \
   return func(v7, args, name);                                          \
 }
 
+#ifdef _WIN32
+static double round(double n) {
+  return n;
+}
+#endif
+
 DEFINE_WRAPPER(fabs, m_one_arg)
 DEFINE_WRAPPER(acos, m_one_arg)
 DEFINE_WRAPPER(asin, m_one_arg)

--- a/src/mm.h
+++ b/src/mm.h
@@ -14,8 +14,8 @@ struct gc_arena {
   char *free;  /* head of free list */
   size_t cell_size;
 
-  uint64_t allocations;  /* cumulative counter of allocations */
-  uint32_t alive;        /* number of living cells */
+  unsigned long allocations;  /* cumulative counter of allocations */
+  unsigned long alive;        /* number of living cells */
 
   int verbose;
   const char *name; /* for debugging purposes */

--- a/tests/ecma_report.txt
+++ b/tests/ecma_report.txt
@@ -2069,7 +2069,7 @@
 2065	PASS ch11/11.6/11.6.1/S11.6.1_A2.1_T2.js (tail -c +1598918 tests/ecmac.db|head -c 439)
 2066	PASS ch11/11.6/11.6.1/S11.6.1_A2.1_T3.js (tail -c +1599358 tests/ecmac.db|head -c 439)
 2067	FAIL ch11/11.6/11.6.1/S11.6.1_A2.2_T1.js (tail -c +1599798 tests/ecmac.db|head -c 2951): [{"message":"#5: 1 + {toString: function() {return 1}} === 2. Actual: 1{"toString":[function()]}"}]
-2068	FAIL ch11/11.6/11.6.1/S11.6.1_A2.2_T2.js (tail -c +1602750 tests/ecmac.db|head -c 1064): [{"message":"#1: var date = new Date(); date + date === date.toString() + date.toString(). Actual: 2.8501e+12"}]
+2068	FAIL ch11/11.6/11.6.1/S11.6.1_A2.2_T2.js (tail -c +1602750 tests/ecmac.db|head -c 1064): [{"message":"#1: var date = new Date(); date + date === date.toString() + date.toString(). Actual: 2.8501e+09"}]
 2069	FAIL ch11/11.6/11.6.1/S11.6.1_A2.2_T3.js (tail -c +1603815 tests/ecmac.db|head -c 1141): [{"message":"#1: function f1() {return 0;}; f1 + 1 === f1.toString() + 1"}]
 2070	PASS ch11/11.6/11.6.1/S11.6.1_A2.3_T1.js (tail -c +1604957 tests/ecmac.db|head -c 858)
 2071	PASS ch11/11.6/11.6.1/S11.6.1_A2.4_T1.js (tail -c +1605816 tests/ecmac.db|head -c 464)
@@ -9692,7 +9692,7 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 9638	PASS ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A2_T1.js (tail -c +8768885 tests/ecmac.db|head -c 778)
 9639	PASS ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A3_T1.js (tail -c +8769664 tests/ecmac.db|head -c 810)
 9640	PASS ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A3_T2.js (tail -c +8770475 tests/ecmac.db|head -c 1508)
-9641	FAIL ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A3_T3.js (tail -c +8771984 tests/ecmac.db|head -c 795): [{"message":"#2.2: x = []; x.length = 4294967296 throw RangeError. Actual: {"message":"#2.1: x = []; x.length = 4294967296 throw RangeError. Actual: x.length === 4.29497e+09"}"}]
+9641	FAIL ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A3_T3.js (tail -c +8771984 tests/ecmac.db|head -c 795): [{"message":"#1: x = []; x.length = 4294967295; x.length === 4294967295"}]
 9642	PASS ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A3_T4.js (tail -c +8772780 tests/ecmac.db|head -c 1074)
 9643	FAIL ch15/15.5/15.5.1/S15.5.1.1_A1_T1.js (tail -c +8773855 tests/ecmac.db|head -c 922): [{"message":"#2: __str = String(function(){}()); __str === "undefined". Actual: __str ==="}]
 9644	PASS ch15/15.5/15.5.1/S15.5.1.1_A1_T10.js (tail -c +8774778 tests/ecmac.db|head -c 1477)

--- a/v7.h
+++ b/v7.h
@@ -34,9 +34,11 @@ enum v7_err {
 struct v7;     /* Opaque structure. V7 engine handler. */
 struct v7_val; /* Opaque structure. Holds V7 value, which has v7_type type. */
 
-
-/* TODO(lsm): fix this. */
+#ifdef _WIN32
+typedef unsigned __int64 uint64_t;
+#else
 #include <inttypes.h>
+#endif
 typedef uint64_t v7_val_t;
 
 typedef v7_val_t (*v7_cfunction_t)(struct v7 *, v7_val_t, v7_val_t);


### PR DESCRIPTION
Re-enable GC.
Fix short strings behavior on 32-bit archs (strings were truncated because of the implicit pointer conversion).