### PR TITLE
Enhance readability of GC code

### DIFF
--- a/src/gc.h
+++ b/src/gc.h
@@ -9,18 +9,23 @@
 #include "internal.h"
 #include "vm.h"
 
+
+/* Disable GC on 32-bit platform for now */
+#if ULONG_MAX == 4294967295
 #define V7_DISABLE_GC
+#endif
 
-#define MARK(p) (* (uintptr_t *) &(p) |= 1)
-
-/* call only on already marked values */
-#define UNMARK(p) (* (uintptr_t *) &(p) &= ~1)
-
-#define MARKED(p) ((uintptr_t) (p) & 1)
+#define MARK(p)   (((struct gc_cell *) (p))->word |= 1)
+#define UNMARK(p) (((struct gc_cell *) (p))->word &= ~1)
+#define MARKED(p) (((struct gc_cell *) (p))->word & 1)
 
 struct gc_tmp_frame {
   struct v7 *v7;
   size_t pos;
+};
+
+struct gc_cell {
+  uintptr_t word;
 };
 
 #define GC_TMP_FRAME(v) __attribute__((cleanup(tmp_frame_cleanup), unused)) \

--- a/tests/ecma_report.txt
+++ b/tests/ecma_report.txt
@@ -2069,7 +2069,7 @@
 2065	PASS ch11/11.6/11.6.1/S11.6.1_A2.1_T2.js (tail -c +1598918 tests/ecmac.db|head -c 439)
 2066	PASS ch11/11.6/11.6.1/S11.6.1_A2.1_T3.js (tail -c +1599358 tests/ecmac.db|head -c 439)
 2067	FAIL ch11/11.6/11.6.1/S11.6.1_A2.2_T1.js (tail -c +1599798 tests/ecmac.db|head -c 2951): [{"message":"#5: 1 + {toString: function() {return 1}} === 2. Actual: 1{"toString":[function()]}"}]
-2068	FAIL ch11/11.6/11.6.1/S11.6.1_A2.2_T2.js (tail -c +1602750 tests/ecmac.db|head -c 1064): [{"message":"#1: var date = new Date(); date + date === date.toString() + date.toString(). Actual: 2.84994e+12"}]
+2068	FAIL ch11/11.6/11.6.1/S11.6.1_A2.2_T2.js (tail -c +1602750 tests/ecmac.db|head -c 1064): [{"message":"#1: var date = new Date(); date + date === date.toString() + date.toString(). Actual: 2.8501e+12"}]
 2069	FAIL ch11/11.6/11.6.1/S11.6.1_A2.2_T3.js (tail -c +1603815 tests/ecmac.db|head -c 1141): [{"message":"#1: function f1() {return 0;}; f1 + 1 === f1.toString() + 1"}]
 2070	PASS ch11/11.6/11.6.1/S11.6.1_A2.3_T1.js (tail -c +1604957 tests/ecmac.db|head -c 858)
 2071	PASS ch11/11.6/11.6.1/S11.6.1_A2.4_T1.js (tail -c +1605816 tests/ecmac.db|head -c 464)
@@ -9692,7 +9692,7 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 9638	PASS ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A2_T1.js (tail -c +8768885 tests/ecmac.db|head -c 778)
 9639	PASS ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A3_T1.js (tail -c +8769664 tests/ecmac.db|head -c 810)
 9640	PASS ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A3_T2.js (tail -c +8770475 tests/ecmac.db|head -c 1508)
-9641	FAIL ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A3_T3.js (tail -c +8771984 tests/ecmac.db|head -c 795): [{"message":"#1: x = []; x.length = 4294967295; x.length === 4294967295"}]
+9641	FAIL ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A3_T3.js (tail -c +8771984 tests/ecmac.db|head -c 795): [{"message":"#2.2: x = []; x.length = 4294967296 throw RangeError. Actual: {"message":"#2.1: x = []; x.length = 4294967296 throw RangeError. Actual: x.length === 4.29497e+09"}"}]
 9642	PASS ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A3_T4.js (tail -c +8772780 tests/ecmac.db|head -c 1074)
 9643	FAIL ch15/15.5/15.5.1/S15.5.1.1_A1_T1.js (tail -c +8773855 tests/ecmac.db|head -c 922): [{"message":"#2: __str = String(function(){}()); __str === "undefined". Actual: __str ==="}]
 9644	PASS ch15/15.5/15.5.1/S15.5.1.1_A1_T10.js (tail -c +8774778 tests/ecmac.db|head -c 1477)
@@ -11142,7 +11142,7 @@ $I: [{"message":"#1: Incorrect value of Date"}]
 11066	PASS ch15/15.9/15.9.5/15.9.5.43/15.9.5.43-0-16.js (tail -c +10078357 tests/ecmac.db|head -c 596)
 11067	FAIL ch15/15.9/15.9.5/15.9.5.43/15.9.5.43-0-2.js (tail -c +10078954 tests/ecmac.db|head -c 335): [{"message":"Test case returned non-true value!"}]
 11068	PASS ch15/15.9/15.9.5/15.9.5.43/15.9.5.43-0-3.js (tail -c +10079290 tests/ecmac.db|head -c 326)
-11069	PASS ch15/15.9/15.9.5/15.9.5.43/15.9.5.43-0-4.js (tail -c +10079617 tests/ecmac.db|head -c 535)
+11069	FAIL ch15/15.9/15.9.5/15.9.5.43/15.9.5.43-0-4.js (tail -c +10079617 tests/ecmac.db|head -c 535): [{"message":"Test case returned non-true value!"}]
 11070	FAIL ch15/15.9/15.9.5/15.9.5.43/15.9.5.43-0-5.js (tail -c +10080153 tests/ecmac.db|head -c 383): [{"message":"Test case returned non-true value!"}]
 11071	PASS ch15/15.9/15.9.5/15.9.5.43/15.9.5.43-0-6.js (tail -c +10080537 tests/ecmac.db|head -c 483)
 11072	PASS ch15/15.9/15.9.5/15.9.5.43/15.9.5.43-0-7.js (tail -c +10081021 tests/ecmac.db|head -c 463)

--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -1678,45 +1678,45 @@ static const char *test_gc_mark(void) {
 
   v7_exec(v7, &v, "o=({a:{b:1},c:{d:2},e:null});o.e=o;o");
   gc_mark(v7, v);
-  ASSERT(MARKED(v7_to_object(v)->properties));
+  ASSERT(MARKED(v7_to_object(v)));
   v7_destroy(v7);
   v7 = v7_create();
 
   v7_exec(v7, &v, "o=({a:{b:1},c:{d:2},e:null});o.e=o;o");
   gc_mark(v7, v7->global_object);
-  ASSERT(MARKED(v7_to_object(v)->properties));
+  ASSERT(MARKED(v7_to_object(v)));
   v7_destroy(v7);
   v7 = v7_create();
 
   v7_exec(v7, &v, "function f() {}; o=new f;o");
   gc_mark(v7, v);
-  ASSERT(MARKED(v7_to_object(v)->properties));
+  ASSERT(MARKED(v7_to_object(v)));
   v7_destroy(v7);
   v7 = v7_create();
 
   v7_exec(v7, &v, "function f() {}; Object.getPrototypeOf(new f)");
   gc_mark(v7, v7->global_object);
-  ASSERT(MARKED(v7_to_object(v)->properties));
+  ASSERT(MARKED(v7_to_object(v)));
   v7_destroy(v7);
   v7 = v7_create();
 
   v7_exec(v7, &v, "({a:1})");
   gc_mark(v7, v7->global_object);
-  ASSERT(!MARKED(v7_to_object(v)->properties));
+  ASSERT(!MARKED(v7_to_object(v)));
   v7_destroy(v7);
   v7 = v7_create();
 
   v7_exec(v7, &v, "var f;(function() {var x={a:1};f=function(){return x};return x})()");
   gc_mark(v7, v7->global_object);
   /* `x` is reachable through `f`'s closure scope */
-  ASSERT(MARKED(v7_to_object(v)->properties));
+  ASSERT(MARKED(v7_to_object(v)));
   v7_destroy(v7);
   v7 = v7_create();
 
   v7_exec(v7, &v, "(function() {var x={a:1};var f=function(){return x};return x})()");
   gc_mark(v7, v7->global_object);
   /* `f` is unreachable, hence `x` is not marked through the scope */
-  ASSERT(!MARKED(v7_to_object(v)->properties));
+  ASSERT(!MARKED(v7_to_object(v)));
   v7_destroy(v7);
   v7 = v7_create();
 


### PR DESCRIPTION
Cleanup (UN)MARK(ED) macros and use a more self-documenting approach
for accessing the first pointer of a GC cell.

---

Hi @cpq, please tell me whether this is more readable
and maintanable than the previous mess.