### PR TITLE
Remove special casing for C constructors

### DIFF
--- a/src/boolean.c
+++ b/src/boolean.c
@@ -53,9 +53,8 @@ static val_t Boolean_toString(struct v7 *v7, val_t this_obj, val_t args) {
 }
 
 V7_PRIVATE void init_boolean(struct v7 *v7) {
-  val_t boolean = v7_create_cfunction(Boolean_ctor);
-  v7_set_property(v7, v7->global_object, "Boolean", 7, 0, boolean);
-  v7_set(v7, v7->boolean_prototype, "constructor", 11, boolean);
+  val_t ctor = v7_create_cfunction_ctor(v7, v7->boolean_prototype, Boolean_ctor, 1);
+  v7_set_property(v7, v7->global_object, "Boolean", 7, 0, ctor);
 
   set_cfunc_prop(v7, v7->boolean_prototype, "valueOf", Boolean_valueOf);
   set_cfunc_prop(v7, v7->boolean_prototype, "toString", Boolean_toString);

--- a/src/date.c
+++ b/src/date.c
@@ -844,10 +844,8 @@ static val_t Date_getTimezoneOffset(struct v7 *v7, val_t this_obj, val_t args) {
 static val_t Date_now(struct v7 *v7, val_t this_obj, val_t args) {
   etime_t ret_time;
   (void) args;
-
-  if (!d_iscalledasfunction(v7, this_obj)) {
-    throw_exception(v7, "TypeError", "Date.now() called on object");
-  }
+  (void) v7;
+  (void) this_obj;
 
   d_gettime(&ret_time);
 
@@ -909,15 +907,9 @@ static int d_set_cfunc_prop(struct v7 *v7, val_t o, const char *name,
   d_set_cfunc_prop(v7, v7->date_prototype, "set"#func, Date_set##func);
 
 V7_PRIVATE void init_date(struct v7 *v7) {
-  val_t date = create_object(v7, v7->date_prototype);
-  val_t ctor = v7_create_cfunction(Date_ctor);
-  unsigned int attrs = V7_PROPERTY_READ_ONLY |
-                       V7_PROPERTY_DONT_ENUM | V7_PROPERTY_DONT_DELETE;
-  v7_set_property(v7, date, "", 0, V7_PROPERTY_HIDDEN, ctor);
-  v7_set_property(v7, date, "prototype", 9, attrs, v7->date_prototype);
-  d_set_cfunc_prop(v7, v7->date_prototype, "constructor", Date_ctor);
-  v7_set_property(v7, v7->global_object, "Date", 4,
-                  V7_PROPERTY_DONT_ENUM, date);
+  val_t date = v7_create_cfunction_ctor(v7, v7->date_prototype, Date_ctor, 7);
+  v7_set_property(v7, v7->global_object, "Date", 4, V7_PROPERTY_DONT_ENUM,
+                  date);
 
   DECLARE_GET_AND_SET(Date);
   DECLARE_GET_AND_SET(FullYear);
@@ -928,6 +920,10 @@ V7_PRIVATE void init_date(struct v7 *v7) {
   DECLARE_GET_AND_SET(Milliseconds);
   DECLARE_GET(Day);
 
+  d_set_cfunc_prop(v7, date, "now", Date_now);
+  d_set_cfunc_prop(v7, date, "parse", Date_parse);
+  d_set_cfunc_prop(v7, date, "UTC", Date_UTC);
+
   d_set_cfunc_prop(v7, v7->date_prototype, "getTimezoneOffset",
                    Date_getTimezoneOffset);
 
@@ -936,9 +932,6 @@ V7_PRIVATE void init_date(struct v7 *v7) {
   d_set_cfunc_prop(v7, v7->date_prototype, "valueOf", Date_valueOf);
 
   d_set_cfunc_prop(v7, v7->date_prototype, "setTime", Date_setTime);
-  d_set_cfunc_prop(v7, v7->date_prototype, "now", Date_now);
-  d_set_cfunc_prop(v7, v7->date_prototype, "parse", Date_parse);
-  d_set_cfunc_prop(v7, v7->date_prototype, "UTC", Date_UTC);
   d_set_cfunc_prop(v7, v7->date_prototype, "toString", Date_toString);
   d_set_cfunc_prop(v7, v7->date_prototype, "toDateString", Date_toDateString);
   d_set_cfunc_prop(v7, v7->date_prototype, "toTimeString", Date_toTimeString);

--- a/src/number.c
+++ b/src/number.c
@@ -81,14 +81,10 @@ static val_t n_isNaN(struct v7 *v7, val_t this_obj, val_t args) {
 }
 
 V7_PRIVATE void init_number(struct v7 *v7) {
-  val_t num = create_object(v7, v7->number_prototype);
-  val_t ctor = v7_create_cfunction(Number_ctor);
   unsigned int attrs = V7_PROPERTY_READ_ONLY | V7_PROPERTY_DONT_ENUM |
                        V7_PROPERTY_DONT_DELETE;
-  v7_set_property(v7, num, "", 0, V7_PROPERTY_HIDDEN, ctor);
-  v7_set_property(v7, num, "prototype", 9, attrs, v7->number_prototype);
-  v7_set_property(v7, v7->number_prototype, "constructor", 11, attrs, num);
-  v7_set_property(v7, v7->global_object, "Number", 6, 0, num);
+  val_t num = v7_create_cfunction_ctor(v7, v7->number_prototype, Number_ctor, 1);
+  v7_set_property(v7, v7->global_object, "Number", 6, V7_PROPERTY_DONT_ENUM, num);
 
   set_cfunc_prop(v7, v7->number_prototype, "toFixed", Number_toFixed);
   set_cfunc_prop(v7, v7->number_prototype, "toPrecision", Number_toPrecision);

--- a/src/string.c
+++ b/src/string.c
@@ -513,9 +513,9 @@ static val_t Str_split(struct v7 *v7, val_t this_obj, val_t args) {
 }
 
 V7_PRIVATE void init_string(struct v7 *v7) {
-  val_t str = v7_create_cfunction(String_ctor);
-  v7_set_property(v7, v7->global_object, "String", 6, 0, str);
-  v7_set(v7, v7->string_prototype, "constructor", 11, str);
+  val_t str = v7_create_cfunction_ctor(v7, v7->string_prototype, String_ctor, 1);
+  v7_set_property(v7, v7->global_object, "String", 6, V7_PROPERTY_DONT_ENUM,
+                  str);
 
   set_cfunc_prop(v7, v7->string_prototype, "charCodeAt", Str_charCodeAt);
   set_cfunc_prop(v7, v7->string_prototype, "charAt", Str_charAt);

--- a/src/vm.h
+++ b/src/vm.h
@@ -143,6 +143,9 @@ V7_PRIVATE void init_stdlib(struct v7 *v7);
 V7_PRIVATE int set_cfunc_prop(struct v7 *, val_t, const char *, v7_cfunction_t);
 V7_PRIVATE v7_val_t v7_create_cfunction_object(struct v7 *, v7_cfunction_t,
                                                int);
+V7_PRIVATE v7_val_t v7_create_cfunction_ctor(struct v7 *, val_t, v7_cfunction_t,
+                                             int);
+
 V7_PRIVATE int set_cfunc_obj_prop(struct v7 *, val_t obj, const char *name,
                                   v7_cfunction_t f, int num_args);
 

--- a/tests/ecma_report.txt
+++ b/tests/ecma_report.txt
@@ -844,7 +844,7 @@
 840	FAIL ch09/9.9/S9.9_A6.js (tail -c +657989 tests/ecmac.db|head -c 924): [{"message":"cannot read property 'valueOf' of undefined"}]
 841	PASS ch10/10.1/S10.1.1_A1_T1.js (tail -c +658914 tests/ecmac.db|head -c 471)
 842	PASS ch10/10.1/S10.1.1_A1_T2.js (tail -c +659386 tests/ecmac.db|head -c 850)
-843	FAIL ch10/10.1/S10.1.1_A1_T3.js (tail -c +660237 tests/ecmac.db|head -c 542): [{"message":"#1: typeof(x.constructor)!=="function""}]
+843	PASS ch10/10.1/S10.1.1_A1_T3.js (tail -c +660237 tests/ecmac.db|head -c 542)
 844	FAIL ch10/10.1/S10.1.1_A2_T1.js (tail -c +660780 tests/ecmac.db|head -c 532): [{"message":"[parseInt] is not defined"}]
 845	PASS ch10/10.1/S10.1.6_A1_T1.js (tail -c +661313 tests/ecmac.db|head -c 413)
 846	PASS ch10/10.1/S10.1.6_A1_T2.js (tail -c +661727 tests/ecmac.db|head -c 963)
@@ -1720,8 +1720,8 @@
 1716	FAIL ch11/11.2/11.2.1/S11.2.1_A4_T3.js (tail -c +1279364 tests/ecmac.db|head -c 1554): [{"message":"#1: typeof Function.prototype === "function". Actual: object"}]
 1717	PASS ch11/11.2/11.2.1/S11.2.1_A4_T4.js (tail -c +1280919 tests/ecmac.db|head -c 2387)
 1718	FAIL ch11/11.2/11.2.1/S11.2.1_A4_T5.js (tail -c +1283307 tests/ecmac.db|head -c 4903): [{"message":"#3: typeof String.fromCharCode === "function". Actual: object"}]
-1719	FAIL ch11/11.2/11.2.1/S11.2.1_A4_T6.js (tail -c +1288211 tests/ecmac.db|head -c 1500): [{"message":"#3: typeof Boolean.constructor === "function". Actual: object"}]
-1720	FAIL ch11/11.2/11.2.1/S11.2.1_A4_T7.js (tail -c +1289712 tests/ecmac.db|head -c 2711): [{"message":"#13: typeof Number.prototype.constructor === "function". Actual: object"}]
+1719	PASS ch11/11.2/11.2.1/S11.2.1_A4_T6.js (tail -c +1288211 tests/ecmac.db|head -c 1500)
+1720	PASS ch11/11.2/11.2.1/S11.2.1_A4_T7.js (tail -c +1289712 tests/ecmac.db|head -c 2711)
 1721	PASS ch11/11.2/11.2.1/S11.2.1_A4_T8.js (tail -c +1292424 tests/ecmac.db|head -c 6501)
 1722	PASS ch11/11.2/11.2.1/S11.2.1_A4_T9.js (tail -c +1298926 tests/ecmac.db|head -c 13756)
 1723	FAIL ch11/11.2/11.2.2/S11.2.2_A1.1.js (tail -c +1312683 tests/ecmac.db|head -c 1223): [{"message":"parse error at at line 1 col 4: [ new]"}]
@@ -4474,7 +4474,7 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 4420	PASS ch15/15.2/15.2.3/15.2.3.2/15.2.3.2-1-3.js (tail -c +4773738 tests/ecmac.db|head -c 427)
 4421	PASS ch15/15.2/15.2.3/15.2.3.2/15.2.3.2-1-4.js (tail -c +4774166 tests/ecmac.db|head -c 427)
 4422	PASS ch15/15.2/15.2.3/15.2.3.2/15.2.3.2-1.js (tail -c +4774594 tests/ecmac.db|head -c 402)
-4423	FAIL ch15/15.2/15.2.3/15.2.3.2/15.2.3.2-2-1.js (tail -c +4774997 tests/ecmac.db|head -c 363): [{"message":"Object.getPrototypeOf called on non-object"}]
+4423	FAIL ch15/15.2/15.2.3/15.2.3.2/15.2.3.2-2-1.js (tail -c +4774997 tests/ecmac.db|head -c 363): [{"message":"Test case returned non-true value!"}]
 4424	FAIL ch15/15.2/15.2.3/15.2.3.2/15.2.3.2-2-10.js (tail -c +4775361 tests/ecmac.db|head -c 362): [{"message":"[RegExp] is not defined"}]
 4425	PASS ch15/15.2/15.2.3/15.2.3.2/15.2.3.2-2-11.js (tail -c +4775724 tests/ecmac.db|head -c 360)
 4426	FAIL ch15/15.2/15.2.3/15.2.3.2/15.2.3.2-2-12.js (tail -c +4776085 tests/ecmac.db|head -c 368): [{"message":"[EvalError] is not defined"}]
@@ -4500,7 +4500,7 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 4446	PASS ch15/15.2/15.2.3/15.2.3.2/15.2.3.2-2-31.js (tail -c +4784047 tests/ecmac.db|head -c 310)
 4447	FAIL ch15/15.2/15.2.3/15.2.3.2/15.2.3.2-2-4.js (tail -c +4784358 tests/ecmac.db|head -c 365): [{"message":"Test case returned non-true value!"}]
 4448	FAIL ch15/15.2/15.2.3/15.2.3.2/15.2.3.2-2-5.js (tail -c +4784724 tests/ecmac.db|head -c 359): [{"message":"Test case returned non-true value!"}]
-4449	FAIL ch15/15.2/15.2.3/15.2.3.2/15.2.3.2-2-6.js (tail -c +4785084 tests/ecmac.db|head -c 361): [{"message":"Object.getPrototypeOf called on non-object"}]
+4449	FAIL ch15/15.2/15.2.3/15.2.3.2/15.2.3.2-2-6.js (tail -c +4785084 tests/ecmac.db|head -c 361): [{"message":"Test case returned non-true value!"}]
 4450	FAIL ch15/15.2/15.2.3/15.2.3.2/15.2.3.2-2-7.js (tail -c +4785446 tests/ecmac.db|head -c 361): [{"message":"Test case returned non-true value!"}]
 4451	PASS ch15/15.2/15.2.3/15.2.3.2/15.2.3.2-2-8.js (tail -c +4785808 tests/ecmac.db|head -c 355)
 4452	FAIL ch15/15.2/15.2.3/15.2.3.2/15.2.3.2-2-9.js (tail -c +4786164 tests/ecmac.db|head -c 357): [{"message":"Test case returned non-true value!"}]
@@ -4588,8 +4588,8 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 4534	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-111.js (tail -c +4828487 tests/ecmac.db|head -c 514): [{"message":"Test case returned non-true value!"}]
 4535	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-112.js (tail -c +4829002 tests/ecmac.db|head -c 517): [{"message":"Test case returned non-true value!"}]
 4536	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-113.js (tail -c +4829520 tests/ecmac.db|head -c 514): [{"message":"Test case returned non-true value!"}]
-4537	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-114.js (tail -c +4830035 tests/ecmac.db|head -c 520): [{"message":"cannot read property 'value' of undefined"}]
-4538	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-115.js (tail -c +4830556 tests/ecmac.db|head -c 514): [{"message":"cannot read property 'value' of undefined"}]
+4537	PASS ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-114.js (tail -c +4830035 tests/ecmac.db|head -c 520)
+4538	PASS ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-115.js (tail -c +4830556 tests/ecmac.db|head -c 514)
 4539	PASS ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-116.js (tail -c +4831071 tests/ecmac.db|head -c 568)
 4540	PASS ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-117.js (tail -c +4831640 tests/ecmac.db|head -c 556)
 4541	PASS ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-118.js (tail -c +4832197 tests/ecmac.db|head -c 586)
@@ -4665,11 +4665,11 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 4611	PASS ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-188.js (tail -c +4872364 tests/ecmac.db|head -c 473)
 4612	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-189.js (tail -c +4872838 tests/ecmac.db|head -c 605): [{"message":"Test case returned non-true value!"}]
 4613	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-19.js (tail -c +4873444 tests/ecmac.db|head -c 558): [{"message":"Test case returned non-true value!"}]
-4614	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-190.js (tail -c +4874003 tests/ecmac.db|head -c 607): [{"message":"cannot read property 'writable' of undefined"}]
-4615	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-191.js (tail -c +4874611 tests/ecmac.db|head -c 601): [{"message":"cannot read property 'writable' of undefined"}]
+4614	PASS ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-190.js (tail -c +4874003 tests/ecmac.db|head -c 607)
+4615	PASS ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-191.js (tail -c +4874611 tests/ecmac.db|head -c 601)
 4616	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-192.js (tail -c +4875213 tests/ecmac.db|head -c 637): [{"message":"cannot read property 'writable' of undefined"}]
-4617	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-193.js (tail -c +4875851 tests/ecmac.db|head -c 609): [{"message":"cannot read property 'writable' of undefined"}]
-4618	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-194.js (tail -c +4876461 tests/ecmac.db|head -c 603): [{"message":"cannot read property 'writable' of undefined"}]
+4617	PASS ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-193.js (tail -c +4875851 tests/ecmac.db|head -c 609)
+4618	PASS ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-194.js (tail -c +4876461 tests/ecmac.db|head -c 603)
 4619	PASS ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-195.js (tail -c +4877065 tests/ecmac.db|head -c 607)
 4620	PASS ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-196.js (tail -c +4877673 tests/ecmac.db|head -c 607)
 4621	PASS ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-197.js (tail -c +4878281 tests/ecmac.db|head -c 607)
@@ -4678,7 +4678,7 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 4624	PASS ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-2.js (tail -c +4880109 tests/ecmac.db|head -c 415)
 4625	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-20.js (tail -c +4880525 tests/ecmac.db|head -c 522): [{"message":"cannot read property 'value' of undefined"}]
 4626	PASS ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-200.js (tail -c +4881048 tests/ecmac.db|head -c 623)
-4627	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-201.js (tail -c +4881672 tests/ecmac.db|head -c 601): [{"message":"cannot read property 'writable' of undefined"}]
+4627	PASS ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-201.js (tail -c +4881672 tests/ecmac.db|head -c 601)
 4628	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-202.js (tail -c +4882274 tests/ecmac.db|head -c 587): [{"message":"Test case returned non-true value!"}]
 4629	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-203.js (tail -c +4882862 tests/ecmac.db|head -c 593): [{"message":"Test case returned non-true value!"}]
 4630	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-204.js (tail -c +4883456 tests/ecmac.db|head -c 591): [{"message":"Test case returned non-true value!"}]
@@ -4773,7 +4773,7 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 4719	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-6.js (tail -c +4937782 tests/ecmac.db|head -c 573): [{"message":"cannot read property 'value' of undefined"}]
 4720	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-60.js (tail -c +4938356 tests/ecmac.db|head -c 570): [{"message":"cannot read property 'value' of undefined"}]
 4721	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-61.js (tail -c +4938927 tests/ecmac.db|head -c 546): [{"message":"cannot read property 'value' of undefined"}]
-4722	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-62.js (tail -c +4939474 tests/ecmac.db|head -c 573): [{"message":"Test case returned non-true value!"}]
+4722	PASS ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-62.js (tail -c +4939474 tests/ecmac.db|head -c 573)
 4723	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-63.js (tail -c +4940048 tests/ecmac.db|head -c 558): [{"message":"Test case returned non-true value!"}]
 4724	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-64.js (tail -c +4940607 tests/ecmac.db|head -c 570): [{"message":"Test case returned non-true value!"}]
 4725	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-65.js (tail -c +4941178 tests/ecmac.db|head -c 558): [{"message":"Test case returned non-true value!"}]
@@ -4795,10 +4795,10 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 4741	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-80.js (tail -c +4950226 tests/ecmac.db|head -c 591): [{"message":"Test case returned non-true value!"}]
 4742	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-81.js (tail -c +4950818 tests/ecmac.db|head -c 579): [{"message":"Test case returned non-true value!"}]
 4743	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-82.js (tail -c +4951398 tests/ecmac.db|head -c 552): [{"message":"Test case returned non-true value!"}]
-4744	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-84.js (tail -c +4951951 tests/ecmac.db|head -c 576): [{"message":"Test case returned non-true value!"}]
+4744	PASS ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-84.js (tail -c +4951951 tests/ecmac.db|head -c 576)
 4745	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-85.js (tail -c +4952528 tests/ecmac.db|head -c 567): [{"message":"Test case returned non-true value!"}]
 4746	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-86.js (tail -c +4953096 tests/ecmac.db|head -c 564): [{"message":"Test case returned non-true value!"}]
-4747	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-88.js (tail -c +4953661 tests/ecmac.db|head -c 573): [{"message":"Test case returned non-true value!"}]
+4747	PASS ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-88.js (tail -c +4953661 tests/ecmac.db|head -c 573)
 4748	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-89.js (tail -c +4954235 tests/ecmac.db|head -c 564): [{"message":"Test case returned non-true value!"}]
 4749	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-9.js (tail -c +4954800 tests/ecmac.db|head -c 570): [{"message":"cannot read property 'value' of undefined"}]
 4750	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-90.js (tail -c +4955371 tests/ecmac.db|head -c 582): [{"message":"cannot read property 'value' of undefined"}]
@@ -6207,7 +6207,7 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 6153	PASS ch15/15.2/15.2.3/15.2.3.6/15.2.3.6-4-62.js (tail -c +6123031 tests/ecmac.db|head -c 525)
 6154	FAIL ch15/15.2/15.2.3/15.2.3.6/15.2.3.6-4-620.js (tail -c +6123557 tests/ecmac.db|head -c 1374): [{"message":"cannot read property 'writable' of undefined"}]
 6155	FAIL ch15/15.2/15.2.3/15.2.3.6/15.2.3.6-4-621.js (tail -c +6124932 tests/ecmac.db|head -c 1320): [{"message":"Test case returned non-true value!"}]
-6156	FAIL ch15/15.2/15.2.3/15.2.3.6/15.2.3.6-4-622.js (tail -c +6126253 tests/ecmac.db|head -c 1203): [{"message":"cannot read property 'writable' of undefined"}]
+6156	FAIL ch15/15.2/15.2.3/15.2.3.6/15.2.3.6-4-622.js (tail -c +6126253 tests/ecmac.db|head -c 1203): [{"message":"Test case returned non-true value!"}]
 6157	FAIL ch15/15.2/15.2.3/15.2.3.6/15.2.3.6-4-623.js (tail -c +6127457 tests/ecmac.db|head -c 1365): [{"message":"Test case returned non-true value!"}]
 6158	FAIL ch15/15.2/15.2.3/15.2.3.6/15.2.3.6-4-624.js (tail -c +6128823 tests/ecmac.db|head -c 1320): [{"message":"Test case returned non-true value!"}]
 6159	PASS ch15/15.2/15.2.3/15.2.3.6/15.2.3.6-4-625gs.js (tail -c +6130144 tests/ecmac.db|head -c 600)
@@ -9692,7 +9692,7 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 9638	PASS ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A2_T1.js (tail -c +8768885 tests/ecmac.db|head -c 778)
 9639	PASS ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A3_T1.js (tail -c +8769664 tests/ecmac.db|head -c 810)
 9640	PASS ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A3_T2.js (tail -c +8770475 tests/ecmac.db|head -c 1508)
-9641	FAIL ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A3_T3.js (tail -c +8771984 tests/ecmac.db|head -c 795): [{"message":"#2.2: x = []; x.length = 4294967296 throw RangeError. Actual: {"message":"#2.1: x = []; x.length = 4294967296 throw RangeError. Actual: x.length === 4.29497e+09"}"}]
+9641	FAIL ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A3_T3.js (tail -c +8771984 tests/ecmac.db|head -c 795): [{"message":"#1: x = []; x.length = 4294967295; x.length === 4294967295"}]
 9642	PASS ch15/15.4/15.4.5/15.4.5.2/S15.4.5.2_A3_T4.js (tail -c +8772780 tests/ecmac.db|head -c 1074)
 9643	FAIL ch15/15.5/15.5.1/S15.5.1.1_A1_T1.js (tail -c +8773855 tests/ecmac.db|head -c 922): [{"message":"#2: __str = String(function(){}()); __str === "undefined". Actual: __str ==="}]
 9644	PASS ch15/15.5/15.5.1/S15.5.1.1_A1_T10.js (tail -c +8774778 tests/ecmac.db|head -c 1477)
@@ -9734,17 +9734,17 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 9680	FAIL ch15/15.5/15.5.2/S15.5.2.1_A2_T1.js (tail -c +8834996 tests/ecmac.db|head -c 682): [{"message":"#1: var __str__obj = new String("abba"); String.prototype.isPrototypeOf(__str__obj)===true"}]
 9681	PASS ch15/15.5/15.5.2/S15.5.2.1_A2_T2.js (tail -c +8835679 tests/ecmac.db|head -c 1233)
 9682	FAIL ch15/15.5/15.5.2/S15.5.2.1_A3.js (tail -c +8836913 tests/ecmac.db|head -c 849): [{"message":"#1: var __str__obj = new String("seamaid"); __str__obj.toString = Object.prototype.toString; __str__obj.toString() === "[object String]". Actual: __str__obj.toString() ===[object Object]"}]
-9683	FAIL ch15/15.5/15.5.3/S15.5.3.1_A1.js (tail -c +8837763 tests/ecmac.db|head -c 543): [{"message":"value is not a function"}]
-9684	FAIL ch15/15.5/15.5.3/S15.5.3.1_A2.js (tail -c +8838307 tests/ecmac.db|head -c 1307): [{"message":"value is not a function"}]
-9685	FAIL ch15/15.5/15.5.3/S15.5.3.1_A3.js (tail -c +8839615 tests/ecmac.db|head -c 960): [{"message":"value is not a function"}]
-9686	FAIL ch15/15.5/15.5.3/S15.5.3.1_A4.js (tail -c +8840576 tests/ecmac.db|head -c 1035): [{"message":"value is not a function"}]
+9683	PASS ch15/15.5/15.5.3/S15.5.3.1_A1.js (tail -c +8837763 tests/ecmac.db|head -c 543)
+9684	PASS ch15/15.5/15.5.3/S15.5.3.1_A2.js (tail -c +8838307 tests/ecmac.db|head -c 1307)
+9685	PASS ch15/15.5/15.5.3/S15.5.3.1_A3.js (tail -c +8839615 tests/ecmac.db|head -c 960)
+9686	PASS ch15/15.5/15.5.3/S15.5.3.1_A4.js (tail -c +8840576 tests/ecmac.db|head -c 1035)
 9687	FAIL ch15/15.5/15.5.3/S15.5.3.2_A1.js (tail -c +8841612 tests/ecmac.db|head -c 1246): [{"message":"#1: typeof String.fromCharCode === "function". Actual: typeof String.fromCharCode ===object"}]
 9688	FAIL ch15/15.5/15.5.3/S15.5.3.2_A2.js (tail -c +8842859 tests/ecmac.db|head -c 509): [{"message":"value is not a function"}]
 9689	FAIL ch15/15.5/15.5.3/S15.5.3.2_A3_T1.js (tail -c +8843369 tests/ecmac.db|head -c 599): [{"message":"value is not a function"}]
 9690	FAIL ch15/15.5/15.5.3/S15.5.3.2_A3_T2.js (tail -c +8843969 tests/ecmac.db|head -c 780): [{"message":"value is not a function"}]
 9691	PASS ch15/15.5/15.5.3/S15.5.3.2_A4.js
  * @description Checking if creating "new String.fromCharCode" fai
-9692	FAIL ch15/15.5/15.5.3/S15.5.3_A1.js (tail -c +8845459 tests/ecmac.db|head -c 497): [{"message":"String has length property whose value is 1. Actual: String.length===undefined"}]
+9692	PASS ch15/15.5/15.5.3/S15.5.3_A1.js (tail -c +8845459 tests/ecmac.db|head -c 497)
 9693	FAIL ch15/15.5/15.5.3/S15.5.3_A2_T1.js (tail -c +8845957 tests/ecmac.db|head -c 639): [{"message":"#1: Function.prototype.isPrototypeOf(String) return true. Actual: false"}]
 9694	FAIL ch15/15.5/15.5.3/S15.5.3_A2_T2.js (tail -c +8846597 tests/ecmac.db|head -c 670): [{"message":"#1: Function.prototype.indicator = 1; String.indicator === 1. Actual: String.indicator ===undefined"}]
 9695	PASS ch15/15.5/15.5.4/S15.5.4.1_A1_T1.js (tail -c +8847268 tests/ecmac.db|head -c 611)
@@ -9905,7 +9905,7 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 9848	FAIL ch15/15.5/15.5.4/15.5.4.13/S15.5.4.13_A3_T1.js (tail -c +8991340 tests/ecmac.db|head -c 718): [{"message":"#1: __instance = new Object(); __instance.slice = String.prototype.slice; __instance.slice(0,8) === "[object ". Actual: {"slice""}]
 9849	FAIL ch15/15.5/15.5.4/15.5.4.13/S15.5.4.13_A3_T2.js (tail -c +8992059 tests/ecmac.db|head -c 839): [{"message":"#1: __instance = new Object(); __instance.slice = String.prototype.slice; __instance.slice(8,__instance.toString().length) === "Object]". Actual: :cfunc_"}]
 9850	FAIL ch15/15.5/15.5.4/15.5.4.13/S15.5.4.13_A3_T3.js (tail -c +8992899 tests/ecmac.db|head -c 873): [{"message":"#1: __instance = function(){}; __instance.slice = String.prototype.slice; __instance.slice(-Infinity,8).slice(1,Infinity) === "unction". Actual: "slice""}]
-9851	FAIL ch15/15.5/15.5.4/15.5.4.13/S15.5.4.13_A3_T4.js (tail -c +8993773 tests/ecmac.db|head -c 870): [{"message":"#1: __instance.slice(0,100) === "undefined". Actual: {"slice":cfunc_0x1071a0d90,"value":undefined}"}]
+9851	FAIL ch15/15.5/15.5.4/15.5.4.13/S15.5.4.13_A3_T4.js (tail -c +8993773 tests/ecmac.db|head -c 870): [{"message":"#1: __instance.slice(0,100) === "undefined". Actual: {"slice":cfunc_0x1027a5050,"value":undefined}"}]
 9852	PASS ch15/15.5/15.5.4/15.5.4.13/S15.5.4.13_A6.js (tail -c +8994644 tests/ecmac.db|head -c 573)
 9853	PASS ch15/15.5/15.5.4/15.5.4.13/S15.5.4.13_A7.js (tail -c +8995218 tests/ecmac.db|head -c 477)
 9854	FAIL ch15/15.5/15.5.4/15.5.4.13/S15.5.4.13_A8.js (tail -c +8995696 tests/ecmac.db|head -c 1372): [{"message":"value is not a function"}]
@@ -10058,7 +10058,7 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 10000	FAIL ch15/15.5/15.5.4/15.5.4.16/S15.5.4.16_A10.js (tail -c +9221675 tests/ecmac.db|head -c 1254): [{"message":"value is not a function"}]
 10001	FAIL ch15/15.5/15.5.4/15.5.4.16/S15.5.4.16_A11.js (tail -c +9222930 tests/ecmac.db|head -c 956): [{"message":"value is not a function"}]
 10002	PASS ch15/15.5/15.5.4/15.5.4.16/S15.5.4.16_A1_T1.js (tail -c +9223887 tests/ecmac.db|head -c 706)
-10003	FAIL ch15/15.5/15.5.4/15.5.4.16/S15.5.4.16_A1_T10.js (tail -c +9224594 tests/ecmac.db|head -c 744): [{"message":"#1: var __obj = {toString:function(){return "AB";}}; __obj.toLowerCase = String.prototype.toLowerCase; __obj.toLowerCase() ==="ab". Actual: {"tolowercase":cfunc_0x1071a0d10,"tostring":[function()]}"}]
+10003	FAIL ch15/15.5/15.5.4/15.5.4.16/S15.5.4.16_A1_T10.js (tail -c +9224594 tests/ecmac.db|head -c 744): [{"message":"#1: var __obj = {toString:function(){return "AB";}}; __obj.toLowerCase = String.prototype.toLowerCase; __obj.toLowerCase() ==="ab". Actual: {"tolowercase":cfunc_0x1027a4fd0,"tostring":[function()]}"}]
 10004	FAIL ch15/15.5/15.5.4/15.5.4.16/S15.5.4.16_A1_T11.js (tail -c +9225339 tests/ecmac.db|head -c 770): [{"message":"#1.1: Exception === "intostr". Actual: {"message":"#1: "var x = __obj.toLowerCase()" lead to throwing exception"}"}]
 10005	PASS ch15/15.5/15.5.4/15.5.4.16/S15.5.4.16_A1_T12.js (tail -c +9226110 tests/ecmac.db|head -c 811)
 10006	PASS ch15/15.5/15.5.4/15.5.4.16/S15.5.4.16_A1_T13.js (tail -c +9226922 tests/ecmac.db|head -c 1236)
@@ -10079,7 +10079,7 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 10021	FAIL ch15/15.5/15.5.4/15.5.4.17/S15.5.4.17_A10.js (tail -c +9241813 tests/ecmac.db|head -c 1322): [{"message":"value is not a function"}]
 10022	FAIL ch15/15.5/15.5.4/15.5.4.17/S15.5.4.17_A11.js (tail -c +9243136 tests/ecmac.db|head -c 1004): [{"message":"value is not a function"}]
 10023	PASS ch15/15.5/15.5.4/15.5.4.17/S15.5.4.17_A1_T1.js (tail -c +9244141 tests/ecmac.db|head -c 754)
-10024	FAIL ch15/15.5/15.5.4/15.5.4.17/S15.5.4.17_A1_T10.js (tail -c +9244896 tests/ecmac.db|head -c 797): [{"message":"#1: var __obj = {toString:function(){return "AB";}}; __obj.toLocaleLowerCase = String.prototype.toLocaleLowerCase; __obj.toLocaleLowerCase() ==="ab". Actual: {"tolocalelowercase":cfunc_0x1071a0d10,"tostring":[function()]}"}]
+10024	FAIL ch15/15.5/15.5.4/15.5.4.17/S15.5.4.17_A1_T10.js (tail -c +9244896 tests/ecmac.db|head -c 797): [{"message":"#1: var __obj = {toString:function(){return "AB";}}; __obj.toLocaleLowerCase = String.prototype.toLocaleLowerCase; __obj.toLocaleLowerCase() ==="ab". Actual: {"tolocalelowercase":cfunc_0x1027a4fd0,"tostring":[function()]}"}]
 10025	FAIL ch15/15.5/15.5.4/15.5.4.17/S15.5.4.17_A1_T11.js (tail -c +9245694 tests/ecmac.db|head -c 806): [{"message":"#1.1: Exception === "intostr". Actual: {"message":"#1: "var x = __obj.toLocaleLowerCase()" lead to throwing exception"}"}]
 10026	PASS ch15/15.5/15.5.4/15.5.4.17/S15.5.4.17_A1_T12.js (tail -c +9246501 tests/ecmac.db|head -c 847)
 10027	PASS ch15/15.5/15.5.4/15.5.4.17/S15.5.4.17_A1_T13.js (tail -c +9247349 tests/ecmac.db|head -c 1320)
@@ -10100,7 +10100,7 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 10042	FAIL ch15/15.5/15.5.4/15.5.4.18/S15.5.4.18_A10.js (tail -c +9262979 tests/ecmac.db|head -c 1254): [{"message":"value is not a function"}]
 10043	FAIL ch15/15.5/15.5.4/15.5.4.18/S15.5.4.18_A11.js (tail -c +9264234 tests/ecmac.db|head -c 956): [{"message":"value is not a function"}]
 10044	PASS ch15/15.5/15.5.4/15.5.4.18/S15.5.4.18_A1_T1.js (tail -c +9265191 tests/ecmac.db|head -c 706)
-10045	FAIL ch15/15.5/15.5.4/15.5.4.18/S15.5.4.18_A1_T10.js (tail -c +9265898 tests/ecmac.db|head -c 743): [{"message":"#1: var __obj = {toString:function(){return "Ab";}}; __obj.toUpperCase = String.prototype.toUpperCase; __obj.toUpperCase() ==="AB". Actual: {"TOUPPERCASE":CFUNC_0X1071A0D50,"TOSTRING":[FUNCTION()]}"}]
+10045	FAIL ch15/15.5/15.5.4/15.5.4.18/S15.5.4.18_A1_T10.js (tail -c +9265898 tests/ecmac.db|head -c 743): [{"message":"#1: var __obj = {toString:function(){return "Ab";}}; __obj.toUpperCase = String.prototype.toUpperCase; __obj.toUpperCase() ==="AB". Actual: {"TOUPPERCASE":CFUNC_0X1027A5010,"TOSTRING":[FUNCTION()]}"}]
 10046	FAIL ch15/15.5/15.5.4/15.5.4.18/S15.5.4.18_A1_T11.js (tail -c +9266642 tests/ecmac.db|head -c 769): [{"message":"#1.1: Exception === "intostr". Actual: {"message":"#1: "var x = __obj.toUpperCase()" lead to throwing exception"}"}]
 10047	PASS ch15/15.5/15.5.4/15.5.4.18/S15.5.4.18_A1_T12.js (tail -c +9267412 tests/ecmac.db|head -c 810)
 10048	PASS ch15/15.5/15.5.4/15.5.4.18/S15.5.4.18_A1_T13.js (tail -c +9268223 tests/ecmac.db|head -c 1236)
@@ -10121,7 +10121,7 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 10063	FAIL ch15/15.5/15.5.4/15.5.4.19/S15.5.4.19_A10.js (tail -c +9283111 tests/ecmac.db|head -c 1326): [{"message":"value is not a function"}]
 10064	FAIL ch15/15.5/15.5.4/15.5.4.19/S15.5.4.19_A11.js (tail -c +9284438 tests/ecmac.db|head -c 1004): [{"message":"value is not a function"}]
 10065	PASS ch15/15.5/15.5.4/15.5.4.19/S15.5.4.19_A1_T1.js (tail -c +9285443 tests/ecmac.db|head -c 754)
-10066	FAIL ch15/15.5/15.5.4/15.5.4.19/S15.5.4.19_A1_T10.js (tail -c +9286198 tests/ecmac.db|head -c 797): [{"message":"#1: var __obj = {toString:function(){return "Ab";}}; __obj.toLocaleUpperCase = String.prototype.toLocaleUpperCase; __obj.toLocaleUpperCase() ==="AB". Actual: {"TOLOCALEUPPERCASE":CFUNC_0X1071A0D50,"TOSTRING":[FUNCTION()]}"}]
+10066	FAIL ch15/15.5/15.5.4/15.5.4.19/S15.5.4.19_A1_T10.js (tail -c +9286198 tests/ecmac.db|head -c 797): [{"message":"#1: var __obj = {toString:function(){return "Ab";}}; __obj.toLocaleUpperCase = String.prototype.toLocaleUpperCase; __obj.toLocaleUpperCase() ==="AB". Actual: {"TOLOCALEUPPERCASE":CFUNC_0X1027A5010,"TOSTRING":[FUNCTION()]}"}]
 10067	FAIL ch15/15.5/15.5.4/15.5.4.19/S15.5.4.19_A1_T11.js (tail -c +9286996 tests/ecmac.db|head -c 803): [{"message":"#1.1: Exception === "intostr". Actual: {"message":"#1: "var x = __obj.toLocaleUpperCase()" lead to throwing exception"}"}]
 10068	PASS ch15/15.5/15.5.4/15.5.4.19/S15.5.4.19_A1_T12.js (tail -c +9287800 tests/ecmac.db|head -c 846)
 10069	PASS ch15/15.5/15.5.4/15.5.4.19/S15.5.4.19_A1_T13.js (tail -c +9288647 tests/ecmac.db|head -c 1319)
@@ -10320,7 +10320,7 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 10261	PASS ch15/15.5/15.5.4/15.5.4.6/S15.5.4.6_A1_T9.js (tail -c +9396053 tests/ecmac.db|head -c 721)
 10262	PASS ch15/15.5/15.5.4/15.5.4.6/S15.5.4.6_A2.js (tail -c +9396775 tests/ecmac.db|head -c 1180)
 10263	PASS ch15/15.5/15.5.4/15.5.4.6/S15.5.4.6_A3.js (tail -c +9397956 tests/ecmac.db|head -c 712)
-10264	FAIL ch15/15.5/15.5.4/15.5.4.6/S15.5.4.6_A4_T1.js (tail -c +9398669 tests/ecmac.db|head -c 833): [{"message":"#1: var x; __instance = {toString:function(){return "one"}}; __instance.concat = String.prototype.concat;  __instance.concat("two",x) === "onetwoundefined". Actual: {"concat":cfunc_0x1071a0850,"toString":[function()]}twoundefined"}]
+10264	FAIL ch15/15.5/15.5.4/15.5.4.6/S15.5.4.6_A4_T1.js (tail -c +9398669 tests/ecmac.db|head -c 833): [{"message":"#1: var x; __instance = {toString:function(){return "one"}}; __instance.concat = String.prototype.concat;  __instance.concat("two",x) === "onetwoundefined". Actual: {"concat":cfunc_0x1027a4b10,"toString":[function()]}twoundefined"}]
 10265	FAIL ch15/15.5/15.5.4/15.5.4.6/S15.5.4.6_A4_T2.js (tail -c +9399503 tests/ecmac.db|head -c 943): [{"message":"#1: e === "intostring". Actual: {"message":"value is not a function"}"}]
 10266	PASS ch15/15.5/15.5.4/15.5.4.6/S15.5.4.6_A6.js (tail -c +9400447 tests/ecmac.db|head -c 577)
 10267	FAIL ch15/15.5/15.5.4/15.5.4.6/S15.5.4.6_A7.js
@@ -10427,13 +10427,13 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 10366	FAIL ch15/15.6/15.6.2/S15.6.2.1_A2.js (tail -c +9490624 tests/ecmac.db|head -c 803): [{"message":"#2: Boolean.prototype.isPrototypeOf(x2)"}]
 10367	PASS ch15/15.6/15.6.2/S15.6.2.1_A3.js (tail -c +9491428 tests/ecmac.db|head -c 811)
 10368	FAIL ch15/15.6/15.6.2/S15.6.2.1_A4.js (tail -c +9492240 tests/ecmac.db|head -c 462): [{"message":"#1: The [[Class]] property of the newly constructed object is set to "Boolean""}]
-10369	FAIL ch15/15.6/15.6.3/S15.6.3_A1.js (tail -c +9492703 tests/ecmac.db|head -c 348): [{"message":"value is not a function"}]
+10369	PASS ch15/15.6/15.6.3/S15.6.3_A1.js (tail -c +9492703 tests/ecmac.db|head -c 348)
 10370	FAIL ch15/15.6/15.6.3/S15.6.3_A2.js (tail -c +9493052 tests/ecmac.db|head -c 482): [{"message":"#1: the value of the internal [[Prototype]] property of the Boolean constructor is the Function prototype object."}]
-10371	FAIL ch15/15.6/15.6.3/S15.6.3_A3.js (tail -c +9493535 tests/ecmac.db|head -c 437): [{"message":"value is not a function"}]
+10371	PASS ch15/15.6/15.6.3/S15.6.3_A3.js (tail -c +9493535 tests/ecmac.db|head -c 437)
 10372	FAIL ch15/15.6/15.6.3/15.6.3.1/S15.6.3.1_A1.js (tail -c +9493973 tests/ecmac.db|head -c 647): [{"message":"Boolean.valueOf called on non-boolean object"}]
 10373	PASS ch15/15.6/15.6.3/15.6.3.1/S15.6.3.1_A2.js (tail -c +9494621 tests/ecmac.db|head -c 398)
-10374	FAIL ch15/15.6/15.6.3/15.6.3.1/S15.6.3.1_A3.js (tail -c +9495020 tests/ecmac.db|head -c 368): [{"message":"#1: Boolean.prototype has the attribute DontDelete"}]
-10375	FAIL ch15/15.6/15.6.3/15.6.3.1/S15.6.3.1_A4.js (tail -c +9495389 tests/ecmac.db|head -c 490): [{"message":"value is not a function"}]
+10374	PASS ch15/15.6/15.6.3/15.6.3.1/S15.6.3.1_A3.js (tail -c +9495020 tests/ecmac.db|head -c 368)
+10375	PASS ch15/15.6/15.6.3/15.6.3.1/S15.6.3.1_A4.js (tail -c +9495389 tests/ecmac.db|head -c 490)
 10376	PASS ch15/15.6/15.6.4/S15.6.4.1_A1.js (tail -c +9495880 tests/ecmac.db|head -c 394)
 10377	PASS ch15/15.6/15.6.4/S15.6.4.2_A1_T1.js (tail -c +9496275 tests/ecmac.db|head -c 1148)
 10378	PASS ch15/15.6/15.6.4/S15.6.4.2_A1_T2.js (tail -c +9497424 tests/ecmac.db|head -c 1216)
@@ -10466,7 +10466,7 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 10405	PASS ch15/15.7/15.7.3/S15.7.3_A5.js (tail -c +9519309 tests/ecmac.db|head -c 377)
 10406	PASS ch15/15.7/15.7.3/S15.7.3_A6.js (tail -c +9519687 tests/ecmac.db|head -c 377)
 10407	FAIL ch15/15.7/15.7.3/S15.7.3_A7.js (tail -c +9520065 tests/ecmac.db|head -c 483): [{"message":"#1: the value of the internal [[Prototype]] property of the Number constructor is the Function prototype object."}]
-10408	FAIL ch15/15.7/15.7.3/S15.7.3_A8.js (tail -c +9520549 tests/ecmac.db|head -c 431): [{"message":"#1: Number constructor has length property"}]
+10408	PASS ch15/15.7/15.7.3/S15.7.3_A8.js (tail -c +9520549 tests/ecmac.db|head -c 431)
 10409	PASS ch15/15.7/15.7.3/15.7.3.1/15.7.3.1-1.js (tail -c +9520981 tests/ecmac.db|head -c 464)
 10410	PASS ch15/15.7/15.7.3/15.7.3.1/15.7.3.1-2.js (tail -c +9521446 tests/ecmac.db|head -c 388)
 10411	PASS ch15/15.7/15.7.3/15.7.3.1/S15.7.3.1_A1_T1.js (tail -c +9521835 tests/ecmac.db|head -c 450)
@@ -10806,10 +10806,10 @@ $I: [{"message":"#1: Incorrect value of Date"}]
 10730	FAIL ch15/15.9/15.9.3/S15.9.3.2_A3_T1.1.js (tail -c +9905919 tests/ecmac.db|head -c 1790): [{"message":"value is not a function"}]
 10731	FAIL ch15/15.9/15.9.3/S15.9.3.2_A3_T1.2.js (tail -c +9907710 tests/ecmac.db|head -c 1681): [{"message":"#1: The [[Class]] property of the newly constructed object is set to 'Date'"}]
 10732	PASS ch15/15.9/15.9.4/S15.9.4_A1.js (tail -c +9909392 tests/ecmac.db|head -c 339)
-10733	FAIL ch15/15.9/15.9.4/S15.9.4_A2.js (tail -c +9909732 tests/ecmac.db|head -c 323): [{"message":"#1: The Date constructor has the property "parse""}]
-10734	FAIL ch15/15.9/15.9.4/S15.9.4_A3.js (tail -c +9910056 tests/ecmac.db|head -c 315): [{"message":"#1: The Date constructor has the property "UTC""}]
+10733	PASS ch15/15.9/15.9.4/S15.9.4_A2.js (tail -c +9909732 tests/ecmac.db|head -c 323)
+10734	PASS ch15/15.9/15.9.4/S15.9.4_A3.js (tail -c +9910056 tests/ecmac.db|head -c 315)
 10735	FAIL ch15/15.9/15.9.4/S15.9.4_A4.js (tail -c +9910372 tests/ecmac.db|head -c 475): [{"message":"#1: the value of the internal [[Prototype]] property of the Date constructor is the Function prototype object."}]
-10736	FAIL ch15/15.9/15.9.4/S15.9.4_A5.js (tail -c +9910848 tests/ecmac.db|head -c 426): [{"message":"#1: Date constructor has length property"}]
+10736	PASS ch15/15.9/15.9.4/S15.9.4_A5.js (tail -c +9910848 tests/ecmac.db|head -c 426)
 10737	PASS ch15/15.9/15.9.4/15.9.4.1/S15.9.4.1_A1_T1.js (tail -c +9911275 tests/ecmac.db|head -c 389)
 10738	PASS ch15/15.9/15.9.4/15.9.4.1/S15.9.4.1_A1_T2.js (tail -c +9911665 tests/ecmac.db|head -c 492)
 10739	PASS ch15/15.9/15.9.4/15.9.4.1/S15.9.4.1_A1_T3.js (tail -c +9912158 tests/ecmac.db|head -c 491)
@@ -10876,10 +10876,10 @@ $I: [{"message":"#1: Incorrect value of Date"}]
 10800	PASS ch15/15.9/15.9.5/15.9.5.1/S15.9.5.1_A1_T1.js (tail -c +9935563 tests/ecmac.db|head -c 495)
 10801	PASS ch15/15.9/15.9.5/15.9.5.1/S15.9.5.1_A1_T2.js (tail -c +9936059 tests/ecmac.db|head -c 549)
 10802	PASS ch15/15.9/15.9.5/15.9.5.1/S15.9.5.1_A1_T3.js (tail -c +9936609 tests/ecmac.db|head -c 529)
-10803	FAIL ch15/15.9/15.9.5/15.9.5.1/S15.9.5.1_A2_T1.js (tail -c +9937139 tests/ecmac.db|head -c 480): [{"message":"value is not a function"}]
+10803	PASS ch15/15.9/15.9.5/15.9.5.1/S15.9.5.1_A2_T1.js (tail -c +9937139 tests/ecmac.db|head -c 480)
 10804	PASS ch15/15.9/15.9.5/15.9.5.1/S15.9.5.1_A3_T1.js (tail -c +9937620 tests/ecmac.db|head -c 484)
-10805	FAIL ch15/15.9/15.9.5/15.9.5.1/S15.9.5.1_A3_T2.js (tail -c +9938105 tests/ecmac.db|head -c 588): [{"message":"#1: The Date.prototype.constructor.length property has the attributes DontDelete"}]
-10806	FAIL ch15/15.9/15.9.5/15.9.5.1/S15.9.5.1_A3_T3.js (tail -c +9938694 tests/ecmac.db|head -c 586): [{"message":"value is not a function"}]
+10805	PASS ch15/15.9/15.9.5/15.9.5.1/S15.9.5.1_A3_T2.js (tail -c +9938105 tests/ecmac.db|head -c 588)
+10806	PASS ch15/15.9/15.9.5/15.9.5.1/S15.9.5.1_A3_T3.js (tail -c +9938694 tests/ecmac.db|head -c 586)
 10807	PASS ch15/15.9/15.9.5/15.9.5.10/S15.9.5.10_A1_T1.js (tail -c +9939281 tests/ecmac.db|head -c 497)
 10808	PASS ch15/15.9/15.9.5/15.9.5.10/S15.9.5.10_A1_T2.js (tail -c +9939779 tests/ecmac.db|head -c 551)
 10809	PASS ch15/15.9/15.9.5/15.9.5.10/S15.9.5.10_A1_T3.js (tail -c +9940331 tests/ecmac.db|head -c 531)


### PR DESCRIPTION
Extract common code for creating a constructor in C,
adapt builtin objects constructors and fix mixup of constructor
and prototype methods in `date`.