### PR TITLE
Cleanup obsolete TODO comments and style

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,3 +1,3 @@
 set noparent
-filter=-build,-readability,+whitespace,-whitespace/comments,-runtime/int,-runtime/references,-runtime/printf,-whitespace/parens,-whitespace/newline
+filter=-build,-readability,+whitespace,-whitespace/comments,-runtime/int,-runtime/references,-runtime/printf,-whitespace/parens,-whitespace/newline,-runtime/threadsafe_fn
 linelength=80

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,6 @@ difftest:
 
 cpplint:
 	@$(MAKE) -C tests cpplint
-	cpplint.py --verbose=0 --extensions=c,h src/*.[ch] v7.h 2>&1 >/dev/null| grep -v "Done processing" | grep -v "file excluded by"
 
 docker:
 	@$(MAKE) -C tests docker

--- a/src/ast.h
+++ b/src/ast.h
@@ -13,7 +13,6 @@
 extern "C" {
 #endif  /* __cplusplus */
 
-/* TODO(mkm): reorder */
 enum ast_tag {
   AST_NOP,
   AST_SCRIPT,
@@ -136,9 +135,9 @@ struct ast {
 typedef unsigned long ast_off_t;
 
 struct ast_node_def {
-  const char *name;      /* tag name, for debugging and serialization */
+  const char *name;            /* tag name, for debugging and serialization */
   unsigned char has_varint;    /* has a varint body */
-  unsigned char has_inlined;   /* inlined data whose size is in the varint field */
+  unsigned char has_inlined;   /* inlined data whose size is in varint field */
   unsigned char num_skips;     /* number of skips */
   unsigned char num_subtrees;  /* number of fixed subtrees */
 };

--- a/src/boolean.c
+++ b/src/boolean.c
@@ -53,7 +53,8 @@ static val_t Boolean_toString(struct v7 *v7, val_t this_obj, val_t args) {
 }
 
 V7_PRIVATE void init_boolean(struct v7 *v7) {
-  val_t ctor = v7_create_cfunction_ctor(v7, v7->boolean_prototype, Boolean_ctor, 1);
+  val_t ctor = v7_create_cfunction_ctor(v7, v7->boolean_prototype, Boolean_ctor,
+                                        1);
   v7_set_property(v7, v7->global_object, "Boolean", 7, 0, ctor);
 
   set_cfunc_prop(v7, v7->boolean_prototype, "valueOf", Boolean_valueOf);

--- a/src/gc.c
+++ b/src/gc.c
@@ -25,11 +25,6 @@ V7_PRIVATE struct gc_tmp_frame new_tmp_frame(struct v7 *v7) {
   return frame;
 }
 
-/*
- * TODO(mkm): make this work without GCC/CLANG extensions.
- * It's not hard to do it, but it requires to a big diff in the
- * interpreter which I'd like to postpone.
- */
 V7_PRIVATE void tmp_frame_cleanup(struct gc_tmp_frame *tf) {
   tf->v7->tmp_stack.len = tf->pos;
 }

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -1054,7 +1054,7 @@ static val_t i_eval_stmt(struct v7 *v7, struct ast *a, ast_off_t *pos,
   tmp_stack_push(&tf, &res);
 
   switch (tag) {
-    case AST_SCRIPT: /* TODO(mkm): push up */
+    case AST_SCRIPT:
       end = ast_get_skip(a, *pos, AST_END_SKIP);
       fvar = ast_get_skip(a, *pos, AST_FUNC_FIRST_VAR_SKIP) - 1;
       ast_move_to_children(a, pos);
@@ -1423,7 +1423,6 @@ static val_t i_eval_stmt(struct v7 *v7, struct ast *a, ast_off_t *pos,
       siglongjmp(v7->jmp_buf, CONTINUE_JMP);
       break; /* unreachable */
     case AST_THROW:
-      /* TODO(mkm): store exception value */
       v7->thrown_error = i_eval_expr(v7, a, pos, scope);
       siglongjmp(v7->jmp_buf, THROW_JMP);
       break; /* unreachable */

--- a/src/number.c
+++ b/src/number.c
@@ -83,8 +83,10 @@ static val_t n_isNaN(struct v7 *v7, val_t this_obj, val_t args) {
 V7_PRIVATE void init_number(struct v7 *v7) {
   unsigned int attrs = V7_PROPERTY_READ_ONLY | V7_PROPERTY_DONT_ENUM |
                        V7_PROPERTY_DONT_DELETE;
-  val_t num = v7_create_cfunction_ctor(v7, v7->number_prototype, Number_ctor, 1);
-  v7_set_property(v7, v7->global_object, "Number", 6, V7_PROPERTY_DONT_ENUM, num);
+  val_t num = v7_create_cfunction_ctor(v7, v7->number_prototype, Number_ctor,
+                                       1);
+  v7_set_property(v7, v7->global_object, "Number", 6, V7_PROPERTY_DONT_ENUM,
+                  num);
 
   set_cfunc_prop(v7, v7->number_prototype, "toFixed", Number_toFixed);
   set_cfunc_prop(v7, v7->number_prototype, "toPrecision", Number_toPrecision);

--- a/src/parser.c
+++ b/src/parser.c
@@ -740,8 +740,6 @@ static enum v7_err parse_statement(struct v7 *v7, struct ast *a) {
       break;
   }
 
-  /* TODO(mkm): labels */
-
   TRY(end_of_statement(v7));
   ACCEPT(TOK_SEMICOLON);  /* swallow optional semicolon */
   return V7_OK;

--- a/src/stdlib.c
+++ b/src/stdlib.c
@@ -5,7 +5,6 @@
 
 #include "internal.h"
 
-/* TODO(lsm): remove this when init_stdlib() is upgraded */
 V7_PRIVATE v7_val_t Std_print(struct v7 *v7, val_t this_obj, val_t args) {
   char *p, buf[1024];
   int i, num_args = v7_array_length(v7, args);

--- a/src/string.c
+++ b/src/string.c
@@ -513,7 +513,8 @@ static val_t Str_split(struct v7 *v7, val_t this_obj, val_t args) {
 }
 
 V7_PRIVATE void init_string(struct v7 *v7) {
-  val_t str = v7_create_cfunction_ctor(v7, v7->string_prototype, String_ctor, 1);
+  val_t str = v7_create_cfunction_ctor(v7, v7->string_prototype, String_ctor,
+                                       1);
   v7_set_property(v7, v7->global_object, "String", 6, V7_PROPERTY_DONT_ENUM,
                   str);
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -178,7 +178,6 @@ V7_PRIVATE val_t v_get_prototype(struct v7 *v7, val_t obj) {
 }
 
 V7_PRIVATE val_t create_object(struct v7 *v7, val_t prototype) {
-  /* TODO(mkm): use GC heap */
   struct v7_object *o = new_object(v7);
   if (o == NULL) {
     return V7_NULL;
@@ -364,7 +363,6 @@ V7_PRIVATE int to_str(struct v7 *v7, val_t v, char *buf, size_t size,
         b += v_sprintf_s(b, size - (b - buf), "[");
       }
       for (i = 0; i < len; i++) {
-        /* TODO */
         v_sprintf_s(key, sizeof(key), "%lu", i);
         if ((p = v7_get_property(v7, v, key, -1)) != NULL) {
           b += to_str(v7, p->value, b, size - (b - buf), 1);

--- a/tests/ecma_report.txt
+++ b/tests/ecma_report.txt
@@ -4654,7 +4654,7 @@ d-G]/.exec("a") throw SyntaxError. Actual: {"message":"[RegExp] is not defined"}
 4600	PASS ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-177.js (tail -c +4865806 tests/ecmac.db|head -c 520)
 4601	PASS ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-178.js (tail -c +4866327 tests/ecmac.db|head -c 686)
 4602	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-179.js (tail -c +4867014 tests/ecmac.db|head -c 697): [{"message":"Test case returned non-true value!"}]
-4603	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-18.js (tail -c +4867712 tests/ecmac.db|head -c 552): [{"message":"Test case returned non-true value!"}]
+4603	PASS ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-18.js (tail -c +4867712 tests/ecmac.db|head -c 552)
 4604	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-180.js (tail -c +4868265 tests/ecmac.db|head -c 699): [{"message":"cannot read property 'writable' of undefined"}]
 4605	FAIL ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-182.js (tail -c +4868965 tests/ecmac.db|head -c 607): [{"message":"Test case returned non-true value!"}]
 4606	PASS ch15/15.2/15.2.3/15.2.3.3/15.2.3.3-4-183.js (tail -c +4869573 tests/ecmac.db|head -c 471)

--- a/tests/test.mk
+++ b/tests/test.mk
@@ -40,7 +40,7 @@ PEDANTIC=$(shell gcc --version 2>/dev/null | grep -q clang && echo -pedantic)
 
 ###
 
-# TODO(mkm) fix cxx issues. This file should be the same file used in fossa
+# TODO(mkm) This file should be the same file used in fossa
 # and we should keep it in sync with subtree or something.
 DIALECTS=cxx ansi c99 c11
 SPECIALS=asan msan gcov valgrind m32

--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -1364,8 +1364,7 @@ static const char *test_interpreter(void) {
   ASSERT(v7_exec(v7, &v, "(function(){i=0;do{if(i==5)return i}while(++i)})()") == V7_OK);
   ASSERT(check_value(v7, v, "5"));
 
-  /* TODO(mkm): check for reference error being thrown */
-  /* ASSERT(v7_exec(v7, &v, "(function(x,y){return x+y})(40,2,(function(){return fail})())") == V7_OK); */
+  ASSERT(v7_exec(v7, &v, "(function(x,y){return x+y})(40,2,(function(){return fail})())") == V7_EXEC_EXCEPTION);
 
   ASSERT(v7_exec(v7, &v, "x=42; (function(){return x})()") == V7_OK);
   ASSERT(check_value(v7, v, "42"));
@@ -1777,12 +1776,8 @@ static const char *test_gc_sweep(void) {
   v7_destroy(v7);
 
   v7 = v7_create();
-  v7->property_arena.verbose = 1;
-  v7->object_arena.verbose = 1;
   v7_gc(v7);
-  fprintf(stderr, "-- Running code which exhausts object pool while evaluating \n");
   v7_exec(v7, &v, "for(i=0;i<9;i++)({});for(i=0;i<7;i++){x=(new Number(1))+({} && 1)};x");
-  fprintf(stderr, "-- Done\n");
   ASSERT(check_value(v7, v, "2"));
   v7_gc(v7);
 

--- a/v7.c
+++ b/v7.c
@@ -387,7 +387,6 @@ V7_PRIVATE size_t mbuf_append(struct mbuf *, const char *, size_t);
 extern "C" {
 #endif  /* __cplusplus */
 
-/* TODO(mkm): reorder */
 enum ast_tag {
   AST_NOP,
   AST_SCRIPT,
@@ -510,9 +509,9 @@ struct ast {
 typedef unsigned long ast_off_t;
 
 struct ast_node_def {
-  const char *name;      /* tag name, for debugging and serialization */
+  const char *name;            /* tag name, for debugging and serialization */
   unsigned char has_varint;    /* has a varint body */
-  unsigned char has_inlined;   /* inlined data whose size is in the varint field */
+  unsigned char has_inlined;   /* inlined data whose size is in varint field */
   unsigned char num_skips;     /* number of skips */
   unsigned char num_subtrees;  /* number of fixed subtrees */
 };
@@ -3834,7 +3833,8 @@ static val_t Boolean_toString(struct v7 *v7, val_t this_obj, val_t args) {
 }
 
 V7_PRIVATE void init_boolean(struct v7 *v7) {
-  val_t ctor = v7_create_cfunction_ctor(v7, v7->boolean_prototype, Boolean_ctor, 1);
+  val_t ctor = v7_create_cfunction_ctor(v7, v7->boolean_prototype, Boolean_ctor,
+                                        1);
   v7_set_property(v7, v7->global_object, "Boolean", 7, 0, ctor);
 
   set_cfunc_prop(v7, v7->boolean_prototype, "valueOf", Boolean_valueOf);
@@ -4470,7 +4470,8 @@ static val_t Str_split(struct v7 *v7, val_t this_obj, val_t args) {
 }
 
 V7_PRIVATE void init_string(struct v7 *v7) {
-  val_t str = v7_create_cfunction_ctor(v7, v7->string_prototype, String_ctor, 1);
+  val_t str = v7_create_cfunction_ctor(v7, v7->string_prototype, String_ctor,
+                                       1);
   v7_set_property(v7, v7->global_object, "String", 6, V7_PROPERTY_DONT_ENUM,
                   str);
 
@@ -5300,7 +5301,6 @@ V7_PRIVATE val_t v_get_prototype(struct v7 *v7, val_t obj) {
 }
 
 V7_PRIVATE val_t create_object(struct v7 *v7, val_t prototype) {
-  /* TODO(mkm): use GC heap */
   struct v7_object *o = new_object(v7);
   if (o == NULL) {
     return V7_NULL;
@@ -5486,7 +5486,6 @@ V7_PRIVATE int to_str(struct v7 *v7, val_t v, char *buf, size_t size,
         b += v_sprintf_s(b, size - (b - buf), "[");
       }
       for (i = 0; i < len; i++) {
-        /* TODO */
         v_sprintf_s(key, sizeof(key), "%lu", i);
         if ((p = v7_get_property(v7, v, key, -1)) != NULL) {
           b += to_str(v7, p->value, b, size - (b - buf), 1);
@@ -6131,11 +6130,6 @@ V7_PRIVATE struct gc_tmp_frame new_tmp_frame(struct v7 *v7) {
   return frame;
 }
 
-/*
- * TODO(mkm): make this work without GCC/CLANG extensions.
- * It's not hard to do it, but it requires to a big diff in the
- * interpreter which I'd like to postpone.
- */
 V7_PRIVATE void tmp_frame_cleanup(struct gc_tmp_frame *tf) {
   tf->v7->tmp_stack.len = tf->pos;
 }
@@ -7059,8 +7053,6 @@ static enum v7_err parse_statement(struct v7 *v7, struct ast *a) {
       PARSE(expression);
       break;
   }
-
-  /* TODO(mkm): labels */
 
   TRY(end_of_statement(v7));
   ACCEPT(TOK_SEMICOLON);  /* swallow optional semicolon */
@@ -8243,7 +8235,7 @@ static val_t i_eval_stmt(struct v7 *v7, struct ast *a, ast_off_t *pos,
   tmp_stack_push(&tf, &res);
 
   switch (tag) {
-    case AST_SCRIPT: /* TODO(mkm): push up */
+    case AST_SCRIPT:
       end = ast_get_skip(a, *pos, AST_END_SKIP);
       fvar = ast_get_skip(a, *pos, AST_FUNC_FIRST_VAR_SKIP) - 1;
       ast_move_to_children(a, pos);
@@ -8612,7 +8604,6 @@ static val_t i_eval_stmt(struct v7 *v7, struct ast *a, ast_off_t *pos,
       siglongjmp(v7->jmp_buf, CONTINUE_JMP);
       break; /* unreachable */
     case AST_THROW:
-      /* TODO(mkm): store exception value */
       v7->thrown_error = i_eval_expr(v7, a, pos, scope);
       siglongjmp(v7->jmp_buf, THROW_JMP);
       break; /* unreachable */
@@ -10738,8 +10729,10 @@ static val_t n_isNaN(struct v7 *v7, val_t this_obj, val_t args) {
 V7_PRIVATE void init_number(struct v7 *v7) {
   unsigned int attrs = V7_PROPERTY_READ_ONLY | V7_PROPERTY_DONT_ENUM |
                        V7_PROPERTY_DONT_DELETE;
-  val_t num = v7_create_cfunction_ctor(v7, v7->number_prototype, Number_ctor, 1);
-  v7_set_property(v7, v7->global_object, "Number", 6, V7_PROPERTY_DONT_ENUM, num);
+  val_t num = v7_create_cfunction_ctor(v7, v7->number_prototype, Number_ctor,
+                                       1);
+  v7_set_property(v7, v7->global_object, "Number", 6, V7_PROPERTY_DONT_ENUM,
+                  num);
 
   set_cfunc_prop(v7, v7->number_prototype, "toFixed", Number_toFixed);
   set_cfunc_prop(v7, v7->number_prototype, "toPrecision", Number_toPrecision);
@@ -11951,7 +11944,6 @@ V7_PRIVATE void init_function(struct v7 *v7) {
  */
 
 
-/* TODO(lsm): remove this when init_stdlib() is upgraded */
 V7_PRIVATE v7_val_t Std_print(struct v7 *v7, val_t this_obj, val_t args) {
   char *p, buf[1024];
   int i, num_args = v7_array_length(v7, args);


### PR DESCRIPTION
Also re-enables a disabled test and fixes
a spurious invocation of cpplint.