### PR TITLE
Split base image from benchmark image

### DIFF
--- a/benchmark/Dockerfile
+++ b/benchmark/Dockerfile
@@ -1,16 +1,4 @@
-FROM cesanta/fossa
-
-RUN apt-get update && apt-get install -y --no-install-recommends curl wget git gnuplot time nodejs && rm -rf /var/lib/apt/lists/*
-
-RUN mkdir -p /v7/graphs && mkdir -p /v7/build && \
-    cd /v7/build; wget http://duktape.org/duktape-1.1.2.tar.xz && \
-    tar xvfJ duktape-1.1.2.tar.xz && cd duktape-1.1.2 && make -f Makefile.cmdline && \
-    mv /v7/build/duktape-1.1.2/duk /v7/ && \
-    cd /v7/build; git clone git://git.ghostscript.com/mujs.git && \
-    cd mujs && make  && \
-    mv /v7/build/mujs/build/mujs /v7/ && \
-    rm -rf /v7/build && \
-    strip /v7/duk /v7/mujs
+FROM cesanta/v7_benchmark_base:latest
 
 COPY v7.* /v7/
 

--- a/benchmark/Dockerfile-base
+++ b/benchmark/Dockerfile-base
@@ -1,0 +1,13 @@
+FROM cesanta/fossa:latest
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl wget git gnuplot time nodejs && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /v7/graphs && mkdir -p /v7/build && \
+    cd /v7/build; wget http://duktape.org/duktape-1.1.2.tar.xz && \
+    tar xvfJ duktape-1.1.2.tar.xz && cd duktape-1.1.2 && make -f Makefile.cmdline && \
+    mv /v7/build/duktape-1.1.2/duk /v7/ && \
+    cd /v7/build; git clone git://git.ghostscript.com/mujs.git && \
+    cd mujs && make  && \
+    mv /v7/build/mujs/build/mujs /v7/ && \
+    rm -rf /v7/build && \
+    strip /v7/duk /v7/mujs

--- a/benchmark/Makefile
+++ b/benchmark/Makefile
@@ -7,5 +7,11 @@ build: ../v7.c ../v7.h
 	cp ../v7.[ch] .
 	docker build -t cesanta/v7_benchmark .
 
+build_base:
+	docker build -t cesanta/v7_benchmark_base -f Dockerfile-base .
+
 push:
 	docker push cesanta/v7_benchmark
+
+push_base:
+	docker push cesanta/v7_benchmark_base


### PR DESCRIPTION
CircleCI doesn't have docker image caching, this avoid
refetching common ubuntu packages on every build

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/v7/378)
<!-- Reviewable:end -->
