### PR TITLE
Fix Socket.connect() on MSVC6

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -192,6 +192,7 @@ static void Socket_getremote_sockaddr(struct v7 *v7, char *addr, uint16_t port,
     case AF_INET: {
       struct sockaddr_in *psa = (struct sockaddr_in *) sa;
       psa->sin_port = htons(port);
+      psa->sin_family = AF_INET;
       memcpy(&psa->sin_addr.s_addr, host->h_addr_list[0],
              sizeof(psa->sin_addr.s_addr));
       break;
@@ -201,6 +202,7 @@ static void Socket_getremote_sockaddr(struct v7 *v7, char *addr, uint16_t port,
       /* TODO(alashkin): verify IPv6 [my provider doesn't support it] */
       struct sockaddr_in6 *psa = (struct sockaddr_in6 *) sa;
       psa->sin6_port = htons(port);
+      psa->sin_family = AF_INET6;
       memcpy(&psa->sin6_addr, host->h_addr_list[0], sizeof(psa->sin6_addr));
 
       break;

--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -564,7 +564,7 @@ static const char *test_stdlib(void) {
   ASSERT(v7_exec(v7, &v, "s.bind(60000)") != V7_OK);
   ASSERT(v7_exec(v7, &v, "s.close()") == V7_OK);
   ASSERT(v7_exec(v7, &v, "var t = new Socket()") == V7_OK);
-  ASSERT(v7_exec(v7, &v, "t.bind(\"non_number\")") != V7_OK);
+  ASSERT(v7_exec(v7, &v, "t.bind('non_number')") != V7_OK);
   ASSERT(v7_exec(v7, &v, "t.bind(12345.25)") == V7_OK);
   ASSERT(v7_exec(v7, &v, "t.close()") == V7_OK);
   ASSERT(v7_exec(v7, &v, "var s = new Socket()") == V7_OK);

--- a/v7.c
+++ b/v7.c
@@ -13164,6 +13164,7 @@ static void Socket_getremote_sockaddr(struct v7 *v7, char *addr, uint16_t port,
     case AF_INET: {
       struct sockaddr_in *psa = (struct sockaddr_in *) sa;
       psa->sin_port = htons(port);
+      psa->sin_family = AF_INET;
       memcpy(&psa->sin_addr.s_addr, host->h_addr_list[0],
              sizeof(psa->sin_addr.s_addr));
       break;
@@ -13173,6 +13174,7 @@ static void Socket_getremote_sockaddr(struct v7 *v7, char *addr, uint16_t port,
       /* TODO(alashkin): verify IPv6 [my provider doesn't support it] */
       struct sockaddr_in6 *psa = (struct sockaddr_in6 *) sa;
       psa->sin6_port = htons(port);
+      psa->sin_family = AF_INET6;
       memcpy(&psa->sin6_addr, host->h_addr_list[0], sizeof(psa->sin6_addr));
 
       break;


### PR DESCRIPTION
Winsock wants `struct sockaddr_in :: sin_family ` set, otherwise `connect()` fails with error 10049 (WSAEADDRNOTAVAIL).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/v7/391)
<!-- Reviewable:end -->
