### PR TITLE
Make VC6 build and test pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ m32_v7: $(TOP_HEADERS) $(TOP_SOURCES) v7.h
 	$(CC) $(TOP_SOURCES) -o v7 -DV7_EXE -DV7_EXPOSE_PRIVATE $(CFLAGS) -m32 -lm
 
 w: v7.c
-	wine cl v7.c /Zi -DV7_EXE -DV7_EXPOSE_PRIVATE
-	wine cl tests/unit_test.c $(TOP_SOURCES) $(V7_FLAGS) /Zi -DV7_EXPOSE_PRIVATE
+	wine cl v7.c /Zi -DV7_EXE -DV7_EXPOSE_PRIVATE $(DEFS_WINDOWS)
+	wine cl tests/unit_test.c $(TOP_SOURCES) $(V7_FLAGS) $(DEFS_WINDOWS) /Zi -DV7_EXPOSE_PRIVATE
 
 clean:
 	@$(MAKE) -C tests clean

--- a/scripts/platform.mk
+++ b/scripts/platform.mk
@@ -16,7 +16,8 @@ ifneq ("$(wildcard /usr/local/bin/llvm-symbolizer-3.5)","")
 endif
 
 # disable optimizations and sockets on windows
-CFLAGS_WINDOWS:=-O0 -DV7_DISABLE_SOCKETS
+DEFS_WINDOWS=-DV7_DISABLE_SOCKETS
+CFLAGS_WINDOWS:=-O0 $(DEFS_WINDOWS)
 CFLAGS_PLATFORM:=
 
 # not all environments set the same env vars

--- a/src/internal.h
+++ b/src/internal.h
@@ -115,11 +115,15 @@ typedef unsigned long uintptr_t;
 #endif
 
 #ifndef NAN
-#define NAN atof("NAN")
+extern double _v7_nan;
+#define HAS_V7_NAN
+#define NAN (_v7_nan)
 #endif
 
 #ifndef INFINITY
-#define INFINITY atof("INFINITY") /* TODO: fix this */
+extern double _v7_infinity;
+#define HAS_V7_INFINITY
+#define INFINITY (_v7_infinity)
 #endif
 
 #ifndef EXIT_SUCCESS

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -142,7 +142,8 @@ static double i_int_bin_op(struct v7 *v7, enum ast_tag tag, double a,
 /* Visual studio 2012+ has signbit() */
 #if defined(V7_WINDOWS) && _MSC_VER < 1700
 static int signbit(double x) {
-  return x > 0;
+  double s = _copysign(1, x);
+  return s < 0;
 }
 #endif
 
@@ -162,6 +163,7 @@ static double i_num_bin_op(struct v7 *v7, enum ast_tag tag, double a,
       return a * b;
     case AST_DIV:
       if (b == 0) {
+        if (a == 0) return NAN;
         return (!signbit(a) == !signbit(b)) ? INFINITY : -INFINITY;
       }
       return a / b;

--- a/src/vm.c
+++ b/src/vm.c
@@ -6,6 +6,14 @@
 #include "internal.h"
 #include "gc.h"
 
+#ifdef HAS_V7_INFINITY
+double _v7_infinity;
+#endif
+
+#ifdef HAS_V7_NAN
+double _v7_nan;
+#endif
+
 enum v7_type val_type(struct v7 *v7, val_t v) {
   int tag;
   if (v7_is_double(v)) {
@@ -1290,6 +1298,17 @@ struct v7 *v7_create(void) {
   struct v7 *v7 = NULL;
   val_t *p;
   char z = 0;
+
+#if defined(HAS_V7_INFINITY) || defined(HAS_V7_NAN)
+  double zero = 0.0;
+#endif
+
+#ifdef HAS_V7_INFINITY
+  _v7_infinity = 1.0 / zero;
+#endif
+#ifdef HAS_V7_NAN
+  _v7_nan = zero / zero;
+#endif
 
   if ((v7 = (struct v7 *) calloc(1, sizeof(*v7))) != NULL) {
     v7->cur_dense_prop =

--- a/tests/ecma_report.txt
+++ b/tests/ecma_report.txt
@@ -2029,7 +2029,7 @@
 2026	PASS ch11/11.5/11.5.2/S11.5.2_A4_T4.js (tail -c +1550682 tests/ecmac.db|head -c 983)
 2027	PASS ch11/11.5/11.5.2/S11.5.2_A4_T5.js (tail -c +1551666 tests/ecmac.db|head -c 1294)
 2028	PASS ch11/11.5/11.5.2/S11.5.2_A4_T6.js (tail -c +1552961 tests/ecmac.db|head -c 1355)
-2029	FAIL ch11/11.5/11.5.2/S11.5.2_A4_T7.js (tail -c +1554317 tests/ecmac.db|head -c 700): [{"message":"#1: +0 / +0 === Not-a-Number. Actual: Infinity"}]
+2029	PASS ch11/11.5/11.5.2/S11.5.2_A4_T7.js (tail -c +1554317 tests/ecmac.db|head -c 700)
 2030	PASS ch11/11.5/11.5.2/S11.5.2_A4_T8.js (tail -c +1555018 tests/ecmac.db|head -c 1663)
 2031	PASS ch11/11.5/11.5.2/S11.5.2_A4_T9.js (tail -c +1556682 tests/ecmac.db|head -c 1211)
 2032	FAIL ch11/11.5/11.5.3/S11.5.3_A1.js (tail -c +1557894 tests/ecmac.db|head -c 1399): [{"message":"#5: 1\u00A0%\u00A01 === 0"}]

--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2004-2013 Sergey Lyubka <valenok@gmail.com>
- * Copyright (c) 2013-2014 Cesanta Software Limited
+ * Copyright (c) 2013-2015 Cesanta Software Limited
  * All rights reserved
  *
  * This library is dual-licensed: you can redistribute it and/or modify
@@ -25,13 +25,13 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <fcntl.h> /* for O_RDWR */
 
 #ifndef _WIN32
 #include <unistd.h>
 #ifndef __WATCOM__
 #include <pthread.h>
 #endif
-#include <fcntl.h>
 #endif
 
 #include "../v7.h"

--- a/v7.c
+++ b/v7.c
@@ -728,11 +728,15 @@ typedef unsigned long uintptr_t;
 #endif
 
 #ifndef NAN
-#define NAN atof("NAN")
+extern double _v7_nan;
+#define HAS_V7_NAN
+#define NAN (_v7_nan)
 #endif
 
 #ifndef INFINITY
-#define INFINITY atof("INFINITY") /* TODO: fix this */
+extern double _v7_infinity;
+#define HAS_V7_INFINITY
+#define INFINITY (_v7_infinity)
 #endif
 
 #ifndef EXIT_SUCCESS
@@ -5339,6 +5343,14 @@ V7_PRIVATE void ast_dump(FILE *fp, struct ast *a, ast_off_t pos) {
  */
 
 
+#ifdef HAS_V7_INFINITY
+double _v7_infinity;
+#endif
+
+#ifdef HAS_V7_NAN
+double _v7_nan;
+#endif
+
 enum v7_type val_type(struct v7 *v7, val_t v) {
   int tag;
   if (v7_is_double(v)) {
@@ -6623,6 +6635,17 @@ struct v7 *v7_create(void) {
   struct v7 *v7 = NULL;
   val_t *p;
   char z = 0;
+
+#if defined(HAS_V7_INFINITY) || defined(HAS_V7_NAN)
+  double zero = 0.0;
+#endif
+
+#ifdef HAS_V7_INFINITY
+  _v7_infinity = 1.0 / zero;
+#endif
+#ifdef HAS_V7_NAN
+  _v7_nan = zero / zero;
+#endif
 
   if ((v7 = (struct v7 *) calloc(1, sizeof(*v7))) != NULL) {
     v7->cur_dense_prop =
@@ -8055,7 +8078,8 @@ static double i_int_bin_op(struct v7 *v7, enum ast_tag tag, double a,
 /* Visual studio 2012+ has signbit() */
 #if defined(V7_WINDOWS) && _MSC_VER < 1700
 static int signbit(double x) {
-  return x > 0;
+  double s = _copysign(1, x);
+  return s < 0;
 }
 #endif
 
@@ -8075,6 +8099,7 @@ static double i_num_bin_op(struct v7 *v7, enum ast_tag tag, double a,
       return a * b;
     case AST_DIV:
       if (b == 0) {
+        if (a == 0) return NAN;
         return (!signbit(a) == !signbit(b)) ? INFINITY : -INFINITY;
       }
       return a / b;


### PR DESCRIPTION
By disabling ECMA tests which are utterly broken on VC6 right now, but this
enables us to run VC6 builds and tests regularly

DIFFBASE=413

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/v7/415)
<!-- Reviewable:end -->
