### PR TITLE
Add makefile wrapper for docker

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec docker run --rm -v $PWD/..:/cesanta -v $PWD/../vc6:/vc6 -t -i cesanta/v7_test "$@"

--- a/scripts/platform.mk
+++ b/scripts/platform.mk
@@ -1,19 +1,21 @@
 CLANG:=clang
+CLANG_FORMAT:=clang-format
+CLANG_TIDY:=clang-tidy
+LLVM_SYMBOLIZER:=llvm-symbolizer
+
+# Needed by presubmit hook, has to run on OSX as well
+
 # installable with: `brew install llvm36 --with-clang`
-CLANG_FORMAT:=/usr/bin/clang-format-3.6
 ifneq ("$(wildcard /usr/local/bin/clang-format-3.6)","")
 	CLANG_FORMAT:=/usr/local/bin/clang-format-3.6
 endif
 
+# might be useful to use lldb
 ifneq ("$(wildcard /usr/local/bin/clang-3.5)","")
 	CLANG:=/usr/local/bin/clang-3.5
 endif
 
-LLVM_SYMBOLIZER:=/usr/bin/llvm-symbolizer
-
-ifneq ("$(wildcard /usr/local/bin/llvm-symbolizer-3.5)","")
-  LLVM_SYMBOLIZER:=/usr/local/bin/llvm-symbolizer-3.5
-endif
+#### TODO(mkm): split
 
 # disable optimizations and sockets on windows
 DEFS_WINDOWS=-DV7_DISABLE_SOCKETS

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -21,5 +21,7 @@ RUN echo 'export VC6=/vc6; export Path=Z:$VC6/bin; export INCLUDE=$VC6/include; 
 # warmup wine
 RUN wine dummy 2>/dev/null || true
 
+ADD dobuild /usr/local/bin/
+
 VOLUME ["/cesanta", "/vc6"]
-ENTRYPOINT ["/usr/bin/make", "-C", "/cesanta/v7", "run", "CFLAGS_EXTRA=-DTEST_UNDER_VIRTUALBOX"]
+ENTRYPOINT ["/usr/local/bin/dobuild", "-C", "/cesanta/v7", "ONDOCKER=1"]

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,11 +13,3 @@ save_want_ast:
 	@rm -f unit_test
 	$(MAKE) test_c99 TEST_FILTER=parser CFLAGS_EXTRA=-DSAVE_AST
 	@rm -f unit_test
-
-# Interactive:
-#   docker run -v $(CURDIR)/../..:/cesanta -t -i --entrypoint=/bin/bash cesanta/v7_test
-docker:
-	docker run --rm -v $(CURDIR)/../..:/cesanta cesanta/v7_test
-
-docker_msan:
-	@docker run --rm -v $(CURDIR)/../..:/cesanta -t -i --entrypoint=/bin/bash cesanta/v7_test -c "cd /cesanta/v7; make -C tests test_msan TEST_FILTER=$(TEST_FILTER)"

--- a/tests/dobuild
+++ b/tests/dobuild
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+export VC6=/vc6; export Path=Z:$VC6/bin; export INCLUDE=$VC6/include; export LIB=$VC6/lib
+exec /usr/bin/make "$@"

--- a/tests/test.mk
+++ b/tests/test.mk
@@ -27,7 +27,6 @@
 # - test_valgrind: run with valgrind
 
 SRC = $(realpath $(PROG).c)
-CLANG:=clang
 
 include ../scripts/platform.mk
 
@@ -103,7 +102,7 @@ alltests: $(ALL_TESTS) lcov cpplint
 # but we don't enforce them for presubmit until they are stable again.
 presubmit: $(SHORT_TESTS) cpplint
 
-.PHONY: clean clean_coverage lcov valgrind docker cpplint
+.PHONY: clean clean_coverage lcov valgrind cpplint
 ifneq ($(V), 1)
 .SILENT: $(ALL_PROGS) $(ALL_TESTS)
 endif


### PR DESCRIPTION
Usage:

TL;DR: `make` for local build, `./make.sh` for dockerized build. In future
advanced builds will be available only through `./make.sh` wrapper.

 - was:
    make docker
  is:
    ./make.sh

 - was:
    docker run --rm -v $PWD/..:/cesanta -v $HOME/Build/vc6:/vc6 -t -i cesanta/v7_test -C tests test_asan TEST_FILTER=inter
  is:
    ./make.sh -C tests test_asan TEST_FILTER=inter

This is a step of the incremental simplification of our makefile:

 - add a wrapper that will execute make via am ephemeral docker container
   passing all the arguments
 - simplify by removing all pseudo targets that invoke other rules via the
   docker client.
   they didn't work well anyway because env were not passed down

TODO: refactor our makefiles so that they perform simple builds everywhere
and delegate all the complicated stuff (asan, msan, symbolizer, lcov, cross
compilation,.... i.e. everything requires specific compiler version or
path) to the makefile executed in the docker environment. Simple builds are
amalgamation, v7 and one unit test flavour.

TODO: make a smarter wrapper

DIFFBASE=418

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/v7/419)
<!-- Reviewable:end -->
