### PR TITLE
Revert "Make OS.uname useful even on non-POSIX platforms."

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -11,6 +11,7 @@
 /* Check whether we're compiling in an environment with no filesystem */
 #if defined(ARDUINO) && (ARDUINO == 106)
 #define V7_NO_FS
+#define V7_NO_POSIX
 #endif
 
 /*
@@ -20,25 +21,6 @@
  * TODO(mkm): selectively disable on clang/gcc once we test this out.
  */
 #define V7_BROKEN_NAN
-
-/* Define platform info for systems that don't have POSIX uname() function. */
-#ifdef V7_NO_POSIX
-#ifndef V7_UNAME_SYSNAME
-#define V7_UNAME_SYSNAME "Unspecified OS"
-#endif
-#ifndef V7_UNAME_NODENAME
-#define V7_UNAME_NODENAME "Unspecified hostname"
-#endif
-#ifndef V7_UNAME_RELEASE
-#define V7_UNAME_RELEASE "Unspecified release"
-#endif
-#ifndef V7_UNAME_VERSION
-#define V7_UNAME_VERSION "Unspecified version"
-#endif
-#ifndef V7_UNAME_MACHINE
-#define V7_UNAME_MACHINE "Unspecified architecture"
-#endif
-#endif
 
 #ifdef __GNUC__
 #define NORETURN __attribute__((noreturn))
@@ -55,9 +37,6 @@
 #define _POSIX_C_SOURCE 200809L
 
 #include <sys/stat.h>
-#ifndef V7_NO_POSIX
-#include <sys/utsname.h>
-#endif
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>
@@ -77,6 +56,7 @@
 #include "../v7.h"
 
 #ifdef V7_WINDOWS
+#define V7_NO_POSIX
 #define vsnprintf _vsnprintf
 #define snprintf _snprintf
 #define isnan(x) _isnan(x)
@@ -94,6 +74,10 @@ typedef unsigned long uintptr_t;
 #include <stdint.h>
 #include <unistd.h>
 #include <fcntl.h>
+#endif
+
+#ifndef V7_NO_POSIX
+#include <sys/utsname.h>
 #endif
 
 /* Private API */

--- a/src/os.c
+++ b/src/os.c
@@ -104,16 +104,14 @@ static val_t OS_rename(struct v7 *v7, val_t this_obj, val_t args) {
 }
 #endif
 
-static val_t OS_uname(struct v7 *v7, val_t this_obj, val_t args) {
 #ifndef V7_NO_POSIX
+static val_t OS_uname(struct v7 *v7, val_t this_obj, val_t args) {
   int res = -1;
   struct utsname name;
-#endif
   val_t ret = v7_create_object(v7);
 
   (void) this_obj;
   (void) args;
-#ifndef V7_NO_POSIX
   res = uname(&name);
 
   v7_set_property(v7, ret, "errno", 5, 0, v7_create_number(res >= 0 ? 0 : errno));
@@ -124,17 +122,9 @@ static val_t OS_uname(struct v7 *v7, val_t this_obj, val_t args) {
     v7_set_property(v7, ret, "version", 7, 0, v7_create_string(v7, name.version, strlen(name.version), 1));
     v7_set_property(v7, ret, "machine", 7, 0, v7_create_string(v7, name.machine, strlen(name.machine), 1));
   }
-#else
-  v7_set_property(v7, ret, "errno", 5, 0, v7_create_number(0));
-  v7_set_property(v7, ret, "sysname", 7, 0, v7_create_string(v7, V7_UNAME_SYSNAME, strlen(V7_UNAME_SYSNAME), 1));
-  v7_set_property(v7, ret, "nodename", 8, 0, v7_create_string(v7, V7_UNAME_NODENAME, strlen(V7_UNAME_NODENAME), 1));
-  v7_set_property(v7, ret, "release", 7, 0, v7_create_string(v7, V7_UNAME_RELEASE, strlen(V7_UNAME_RELEASE), 1));
-  v7_set_property(v7, ret, "version", 7, 0, v7_create_string(v7, V7_UNAME_VERSION, strlen(V7_UNAME_VERSION), 1));
-  v7_set_property(v7, ret, "machine", 7, 0, v7_create_string(v7, V7_UNAME_MACHINE, strlen(V7_UNAME_MACHINE), 1));
-#endif
-
   return ret;
 }
+#endif
 
 V7_PRIVATE void init_os(struct v7 *v7) {
   val_t os_obj = v7_create_object(v7);
@@ -147,5 +137,7 @@ V7_PRIVATE void init_os(struct v7 *v7) {
   set_cfunc_obj_prop(v7, os_obj, "remove", OS_remove);
   set_cfunc_obj_prop(v7, os_obj, "rename", OS_rename);
 #endif
+#ifndef V7_NO_POSIX
   set_cfunc_obj_prop(v7, os_obj, "uname", OS_uname);
+#endif
 }

--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -2084,6 +2084,7 @@ static const char *test_gc_sweep(void) {
 }
 #endif
 
+#ifndef V7_NO_FS
 static const char *test_file(void) {
   v7_val_t v;
   size_t file_len, string_len;
@@ -2126,7 +2127,9 @@ static const char *test_file(void) {
   v7_destroy(v7);
   return NULL;
 }
+#endif
 
+#ifndef V7_NO_POSIX
 static const char *test_os(void) {
   v7_val_t v;
   struct v7 *v7 = v7_create();
@@ -2147,6 +2150,7 @@ static const char *test_os(void) {
 
   return NULL;
 }
+#endif
 
 static const char *run_all_tests(const char *filter) {
   RUN_TEST(test_unescape);
@@ -2156,8 +2160,12 @@ static const char *run_all_tests(const char *filter) {
   RUN_TEST(test_is_true);
   RUN_TEST(test_closure);
   RUN_TEST(test_native_functions);
+#ifndef V7_NO_FS
   RUN_TEST(test_file);
+#endif
+#ifndef V7_NO_POSIX
   RUN_TEST(test_os);
+#endif
   RUN_TEST(test_stdlib);
   RUN_TEST(test_runtime);
   RUN_TEST(test_parser);


### PR DESCRIPTION
And fix conditional compilation on Windows.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/v7/443)
<!-- Reviewable:end -->
