### PR TITLE
Mark a couple vars volatile to make GCC happy

### DIFF
--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -1086,7 +1086,8 @@ static val_t i_eval_stmt(struct v7 *v7, struct ast *a, ast_off_t *pos,
   ast_off_t maybe_strict, start = *pos;
   enum ast_tag tag = ast_fetch_tag(a, pos);
   val_t res = v7_create_undefined();
-  ast_off_t end, end_true, cond, iter_end, loop, iter, finally, acatch, fvar;
+  volatile ast_off_t end; /* Only to pacify GCC. */
+  ast_off_t end_true, cond, iter_end, loop, iter, finally, acatch, fvar;
   int saved_strict_mode = v7->strict_mode;
   struct gc_tmp_frame tf = new_tmp_frame(v7);
   tmp_stack_push(&tf, &res);

--- a/src/slre.c
+++ b/src/slre.c
@@ -1096,7 +1096,7 @@ static void program_print(struct slre_prog *prog) {
 #endif
 
 int slre_compile(const char *pat, size_t pat_len, const char *flags,
-                 size_t fl_len, struct slre_prog **pr, int is_regex) {
+                 volatile size_t fl_len, struct slre_prog **pr, int is_regex) {
   struct slre_env e;
   struct slre_node *nd;
   struct slre_instruction *split, *jump;

--- a/v7.c
+++ b/v7.c
@@ -9090,7 +9090,8 @@ static val_t i_eval_stmt(struct v7 *v7, struct ast *a, ast_off_t *pos,
   ast_off_t maybe_strict, start = *pos;
   enum ast_tag tag = ast_fetch_tag(a, pos);
   val_t res = v7_create_undefined();
-  ast_off_t end, end_true, cond, iter_end, loop, iter, finally, acatch, fvar;
+  volatile ast_off_t end; /* Only to pacify GCC. */
+  ast_off_t end_true, cond, iter_end, loop, iter, finally, acatch, fvar;
   int saved_strict_mode = v7->strict_mode;
   struct gc_tmp_frame tf = new_tmp_frame(v7);
   tmp_stack_push(&tf, &res);
@@ -10772,7 +10773,7 @@ static void program_print(struct slre_prog *prog) {
 #endif
 
 int slre_compile(const char *pat, size_t pat_len, const char *flags,
-                 size_t fl_len, struct slre_prog **pr, int is_regex) {
+                 volatile size_t fl_len, struct slre_prog **pr, int is_regex) {
   struct slre_env e;
   struct slre_node *nd;
   struct slre_instruction *split, *jump;


### PR DESCRIPTION
Squashes the "argument might be clobbered by longjmp" warnings.
Both instances were benign.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/v7/454)
<!-- Reviewable:end -->
