### PR TITLE
Add a make variable that detects gcc vs clang

### DIFF
--- a/scripts/platform.mk
+++ b/scripts/platform.mk
@@ -30,3 +30,5 @@ endif
 ifeq ($(OS),Windows_NT)
 	CFLAGS_PLATFORM:=$(CFLAGS_WINDOWS)
 endif
+
+IS_GCC:=$(shell echo "\#if defined(__GNUC__) && !defined(__clang__)\n\#error IS_GCC\n\#endif" | $(CC) -E - 2>&1 |grep -q IS_GCC && echo 1)


### PR DESCRIPTION
It was written to be able to disable some gcc specific warnings,
but it turns out that we don't want to disable them anymore.
However, it might be useful soon for other kind of compiler specific flags,
and it turned out to be a >15m task so I'd spare it to the next guy.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/v7/455)
<!-- Reviewable:end -->
