### PR TITLE
Fix signed int overflow in SLRE

### DIFF
--- a/src/slre.c
+++ b/src/slre.c
@@ -334,22 +334,24 @@ static void re_ex_num_overfl(struct slre_env *e) {
 
 static enum slre_opcode re_countrep(struct slre_env *e) {
   e->min_rep = 0;
-  while (e->src < e->src_end && !re_endofcount(e->curr_rune = *e->src++))
+  while (e->src < e->src_end && !re_endofcount(e->curr_rune = *e->src++)) {
     e->min_rep = e->min_rep * 10 + re_dec_digit(e, e->curr_rune);
-  if (e->min_rep >= SLRE_MAX_REP) re_ex_num_overfl(e);
+    if (e->min_rep >= SLRE_MAX_REP) re_ex_num_overfl(e);
+  }
 
   if (e->curr_rune != ',') {
     e->max_rep = e->min_rep;
     return L_COUNT;
   }
   e->max_rep = 0;
-  while (e->src < e->src_end && (e->curr_rune = *e->src++) != '}')
+  while (e->src < e->src_end && (e->curr_rune = *e->src++) != '}') {
     e->max_rep = e->max_rep * 10 + re_dec_digit(e, e->curr_rune);
+    if (e->max_rep >= SLRE_MAX_REP) re_ex_num_overfl(e);
+  }
   if (!e->max_rep) {
     e->max_rep = SLRE_MAX_REP;
     return L_COUNT;
   }
-  if (e->max_rep >= SLRE_MAX_REP) re_ex_num_overfl(e);
 
   return L_COUNT;
 }

--- a/v7.c
+++ b/v7.c
@@ -10080,22 +10080,24 @@ static void re_ex_num_overfl(struct slre_env *e) {
 
 static enum slre_opcode re_countrep(struct slre_env *e) {
   e->min_rep = 0;
-  while (e->src < e->src_end && !re_endofcount(e->curr_rune = *e->src++))
+  while (e->src < e->src_end && !re_endofcount(e->curr_rune = *e->src++)) {
     e->min_rep = e->min_rep * 10 + re_dec_digit(e, e->curr_rune);
-  if (e->min_rep >= SLRE_MAX_REP) re_ex_num_overfl(e);
+    if (e->min_rep >= SLRE_MAX_REP) re_ex_num_overfl(e);
+  }
 
   if (e->curr_rune != ',') {
     e->max_rep = e->min_rep;
     return L_COUNT;
   }
   e->max_rep = 0;
-  while (e->src < e->src_end && (e->curr_rune = *e->src++) != '}')
+  while (e->src < e->src_end && (e->curr_rune = *e->src++) != '}') {
     e->max_rep = e->max_rep * 10 + re_dec_digit(e, e->curr_rune);
+    if (e->max_rep >= SLRE_MAX_REP) re_ex_num_overfl(e);
+  }
   if (!e->max_rep) {
     e->max_rep = SLRE_MAX_REP;
     return L_COUNT;
   }
-  if (e->max_rep >= SLRE_MAX_REP) re_ex_num_overfl(e);
 
   return L_COUNT;
 }


### PR DESCRIPTION
Found with clang's -fsanitize=undefined.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/v7/456)
<!-- Reviewable:end -->
