### PR TITLE
Pull out feature-related stuff into v7_features.h

### DIFF
--- a/scripts/gen-features-full.pl
+++ b/scripts/gen-features-full.pl
@@ -21,5 +21,5 @@ print <<EOF
  */
 
 $feature_defs
-#endif
+#endif /* V7_BUILD_PROFILE == V7_BUILD_PROFILE_FULL */
 EOF

--- a/src/features_full.h
+++ b/src/features_full.h
@@ -14,4 +14,4 @@
 #define V7_ENABLE__Date__toLocaleString 1
 #define V7_ENABLE__Date__toString 1
 
-#endif
+#endif /* V7_BUILD_PROFILE == V7_BUILD_PROFILE_FULL */

--- a/src/features_medium.h
+++ b/src/features_medium.h
@@ -4,4 +4,4 @@
 #define V7_ENABLE__Date__now 1
 #define V7_ENABLE__Date__UTC 1
 
-#endif
+#endif /* V7_BUILD_PROFILE == V7_BUILD_PROFILE_MEDIUM */

--- a/src/features_minimal.h
+++ b/src/features_minimal.h
@@ -3,4 +3,4 @@
 #define V7_ENABLE__Date 1
 #define V7_ENABLE__Date__now 1
 
-#endif
+#endif /* V7_BUILD_PROFILE == V7_BUILD_PROFILE_MINIMAL */

--- a/src/internal.h
+++ b/src/internal.h
@@ -76,17 +76,7 @@ typedef unsigned long uintptr_t;
 #include <fcntl.h>
 #endif
 
-#define V7_BUILD_PROFILE_MINIMAL 1
-#define V7_BUILD_PROFILE_MEDIUM 2
-#define V7_BUILD_PROFILE_FULL 3
-
-#ifndef V7_BUILD_PROFILE
-#define V7_BUILD_PROFILE V7_BUILD_PROFILE_FULL
-#endif
-/* Only one will actually be chose based on V7_BUILD_PROFILE guards inside. */
-#include "features_minimal.h"
-#include "features_medium.h"
-#include "features_full.h"
+#include "v7_features.h"
 
 /* Private API */
 #include "utf.h"

--- a/src/sources.mk
+++ b/src/sources.mk
@@ -2,6 +2,6 @@ SOURCES = mbuf.c utf.c varint.c tokenizer.c array.c boolean.c math.c string.c \
           ast.c vm.c gc.c parser.c interpreter.c slre.c object.c error.c \
           number.c json.c main.c date.c function.c stdlib.c js_stdlib.c \
           regex.c socket.c os.c crypto.c
-HEADERS = features_full.h features_medium.h features_minimal.h \
+HEADERS = v7_features.h features_full.h features_medium.h features_minimal.h \
           license.h utf.h tokenizer.h mbuf.h ast.h parser.h mm.h internal.h \
           vm.h gc.h slre.h varint.h

--- a/src/v7_features.h
+++ b/src/v7_features.h
@@ -1,0 +1,17 @@
+#ifndef V7_FEATURES_H_INCLUDED
+#define V7_FEATURES_H_INCLUDED
+
+#define V7_BUILD_PROFILE_MINIMAL 1
+#define V7_BUILD_PROFILE_MEDIUM 2
+#define V7_BUILD_PROFILE_FULL 3
+
+#ifndef V7_BUILD_PROFILE
+#define V7_BUILD_PROFILE V7_BUILD_PROFILE_FULL
+#endif
+
+/* Only one will actually be used based on V7_BUILD_PROFILE. */
+#include "features_minimal.h"
+#include "features_medium.h"
+#include "features_full.h"
+
+#endif /* V7_FEATURES_H_INCLUDED */

--- a/v7.c
+++ b/v7.c
@@ -102,6 +102,20 @@ v7_val_t v7_array_get(struct v7 *, v7_val_t arr, unsigned long index);
 #endif /* __cplusplus */
 
 #endif /* V7_HEADER_INCLUDED */
+#ifndef V7_FEATURES_H_INCLUDED
+#define V7_FEATURES_H_INCLUDED
+
+#define V7_BUILD_PROFILE_MINIMAL 1
+#define V7_BUILD_PROFILE_MEDIUM 2
+#define V7_BUILD_PROFILE_FULL 3
+
+#ifndef V7_BUILD_PROFILE
+#define V7_BUILD_PROFILE V7_BUILD_PROFILE_FULL
+#endif
+
+/* Only one will actually be used based on V7_BUILD_PROFILE. */
+
+#endif /* V7_FEATURES_H_INCLUDED */
 #if V7_BUILD_PROFILE == V7_BUILD_PROFILE_FULL
 /*
  * DO NOT EDIT.
@@ -118,20 +132,20 @@ v7_val_t v7_array_get(struct v7 *, v7_val_t arr, unsigned long index);
 #define V7_ENABLE__Date__toLocaleString 1
 #define V7_ENABLE__Date__toString 1
 
-#endif
+#endif /* V7_BUILD_PROFILE == V7_BUILD_PROFILE_FULL */
 #if V7_BUILD_PROFILE == V7_BUILD_PROFILE_MEDIUM
 
 #define V7_ENABLE__Date 1
 #define V7_ENABLE__Date__now 1
 #define V7_ENABLE__Date__UTC 1
 
-#endif
+#endif /* V7_BUILD_PROFILE == V7_BUILD_PROFILE_MEDIUM */
 #if V7_BUILD_PROFILE == V7_BUILD_PROFILE_MINIMAL
 
 #define V7_ENABLE__Date 1
 #define V7_ENABLE__Date__now 1
 
-#endif
+#endif /* V7_BUILD_PROFILE == V7_BUILD_PROFILE_MINIMAL */
 /*
  * Copyright (c) 2013-2014 Cesanta Software Limited
  * All rights reserved
@@ -739,14 +753,6 @@ typedef unsigned long uintptr_t;
 #include <fcntl.h>
 #endif
 
-#define V7_BUILD_PROFILE_MINIMAL 1
-#define V7_BUILD_PROFILE_MEDIUM 2
-#define V7_BUILD_PROFILE_FULL 3
-
-#ifndef V7_BUILD_PROFILE
-#define V7_BUILD_PROFILE V7_BUILD_PROFILE_FULL
-#endif
-/* Only one will actually be chose based on V7_BUILD_PROFILE guards inside. */
 
 /* Private API */
 


### PR DESCRIPTION
So it can be included into files that do not otherwise need internal.h.

Why not features.h? Because of /usr/include/features.h.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/v7/458)
<!-- Reviewable:end -->
