### PR TITLE
Only generate features_full.h if Perl is available

### DIFF
--- a/.hooks/commit-msg
+++ b/.hooks/commit-msg
@@ -9,7 +9,7 @@ abort() {
     exit 1
 }
 
-if [ "$(head -n 1 $TMP | wc -c)" -gt 50 ]; then
+if [ "$(head -n 1 $TMP | wc -c)" -gt 51 ]; then  # 51 because wc -c includes CR.
     echo "Summary max length is 50 cols"
     abort
 fi

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,10 @@ all: v7 amalgamated_v7
 	@$(MAKE) -C tests
 
 src/features_full.h: $(TOP_SOURCES) scripts/gen-features-full.pl
-	@echo "GENERATING $@"
-	@perl scripts/gen-features-full.pl $(TOP_SOURCES) > $@
+ifdef PERL
+	@echo "GENERATING\t$@"
+	@$(PERL) scripts/gen-features-full.pl $(TOP_SOURCES) > $@
+endif
 
 v7.c: $(TOP_HEADERS) $(TOP_SOURCES) v7.h Makefile
 	@echo "AMALGAMATING\tv7.c"

--- a/scripts/platform.mk
+++ b/scripts/platform.mk
@@ -32,3 +32,8 @@ ifeq ($(OS),Windows_NT)
 endif
 
 IS_GCC:=$(shell echo "\#if defined(__GNUC__) && !defined(__clang__)\n\#error IS_GCC\n\#endif" | $(CC) -E - 2>&1 |grep -q IS_GCC && echo 1)
+
+PERL=$(shell perl -e 'print $$^X' 2>/dev/null)
+ifeq ("${PERL}","")
+	undefine PERL
+endif


### PR DESCRIPTION
Otherwise do nothing, fall back on the checked-in version.

This commit also includes a change to the commit hook that wouldn't
accept the summary which is exactly 50 chars long :)

Fixes #457.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/v7/459)
<!-- Reviewable:end -->
