### PR TITLE
Initial work to make V7 minimal compile for UNO

### DIFF
--- a/examples/uno/Makefile
+++ b/examples/uno/Makefile
@@ -1,0 +1,2 @@
+# No-op for now.
+all:

--- a/examples/uno/uno.ino
+++ b/examples/uno/uno.ino
@@ -1,0 +1,13 @@
+#include <SPI.h>
+
+#include "v7.h"
+
+struct v7 *v7;
+
+void setup() {
+  v7 = v7_create();
+}
+
+void loop() {
+
+}

--- a/src/date.c
+++ b/src/date.c
@@ -7,6 +7,9 @@
 
 #if V7_ENABLE__Date
 
+#include <locale.h>
+#include <time.h>
+
 #ifdef __APPLE__
 int64_t strtoll(const char *, char **, int);
 #elif !defined(_WIN32)

--- a/src/features_minimal.h
+++ b/src/features_minimal.h
@@ -1,6 +1,5 @@
 #if V7_BUILD_PROFILE == V7_BUILD_PROFILE_MINIMAL
 
-#define V7_ENABLE__Date 1
-#define V7_ENABLE__Date__now 1
+/* This space is intentionally left blank. */
 
 #endif /* V7_BUILD_PROFILE == V7_BUILD_PROFILE_MINIMAL */

--- a/src/internal.h
+++ b/src/internal.h
@@ -37,13 +37,11 @@
 
 #define _POSIX_C_SOURCE 200809L
 
-#include <sys/stat.h>
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>
 #include <float.h>
 #include <limits.h>
-#include <locale.h>
 #include <math.h>
 #include <stdarg.h>
 #include <stddef.h>
@@ -51,7 +49,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <setjmp.h>
-#include <time.h>
 
 /* Public API. Implemented in api.c */
 #include "../v7.h"
@@ -70,10 +67,7 @@ typedef unsigned char uint8_t;
 typedef unsigned long uintptr_t;
 #define __func__ ""
 #else
-#include <sys/time.h>
 #include <stdint.h>
-#include <unistd.h>
-#include <fcntl.h>
 #endif
 
 #include "v7_features.h"

--- a/src/main.c
+++ b/src/main.c
@@ -14,6 +14,9 @@
 #endif
 
 #ifdef V7_MAIN
+
+#include <sys/stat.h>
+
 static void show_usage(char *argv[]) {
   fprintf(stderr, "V7 version %s (c) Cesanta Software, built on %s\n",
           V7_VERSION, __DATE__);

--- a/src/vm.c
+++ b/src/vm.c
@@ -767,8 +767,8 @@ int v7_del_property(struct v7 *v7, val_t obj, const char *name, size_t len) {
   return -1;
 }
 
-v7_val_t
-v7_create_cfunction_object(struct v7 *v7, v7_cfunction_t f, int num_args) {
+v7_val_t v7_create_cfunction_object(struct v7 *v7, v7_cfunction_t f,
+                                    int num_args) {
   val_t obj = create_object(v7, v7->function_prototype);
   struct gc_tmp_frame tf = new_tmp_frame(v7);
   tmp_stack_push(&tf, &obj);

--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <time.h>
 #include <fcntl.h> /* for O_RDWR */
 

--- a/v7.c
+++ b/v7.c
@@ -186,8 +186,7 @@ int v7_main(int argc, char *argv[], void (*init_func)(struct v7 *));
 #endif /* V7_BUILD_PROFILE == V7_BUILD_PROFILE_MEDIUM */
 #if V7_BUILD_PROFILE == V7_BUILD_PROFILE_MINIMAL
 
-#define V7_ENABLE__Date 1
-#define V7_ENABLE__Date__now 1
+/* This space is intentionally left blank. */
 
 #endif /* V7_BUILD_PROFILE == V7_BUILD_PROFILE_MINIMAL */
 /*
@@ -760,13 +759,11 @@ struct gc_arena {
 
 #define _POSIX_C_SOURCE 200809L
 
-#include <sys/stat.h>
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>
 #include <float.h>
 #include <limits.h>
-#include <locale.h>
 #include <math.h>
 #include <stdarg.h>
 #include <stddef.h>
@@ -774,7 +771,6 @@ struct gc_arena {
 #include <stdlib.h>
 #include <string.h>
 #include <setjmp.h>
-#include <time.h>
 
 /* Public API. Implemented in api.c */
 
@@ -792,10 +788,7 @@ typedef unsigned char uint8_t;
 typedef unsigned long uintptr_t;
 #define __func__ ""
 #else
-#include <sys/time.h>
 #include <stdint.h>
-#include <unistd.h>
-#include <fcntl.h>
 #endif
 
 
@@ -6232,8 +6225,8 @@ int v7_del_property(struct v7 *v7, val_t obj, const char *name, size_t len) {
   return -1;
 }
 
-v7_val_t
-v7_create_cfunction_object(struct v7 *v7, v7_cfunction_t f, int num_args) {
+v7_val_t v7_create_cfunction_object(struct v7 *v7, v7_cfunction_t f,
+                                    int num_args) {
   val_t obj = create_object(v7, v7->function_prototype);
   struct gc_tmp_frame tf = new_tmp_frame(v7);
   tmp_stack_push(&tf, &obj);
@@ -11900,6 +11893,9 @@ V7_PRIVATE void init_json(struct v7 *v7) {
 #endif
 
 #ifdef V7_MAIN
+
+#include <sys/stat.h>
+
 static void show_usage(char *argv[]) {
   fprintf(stderr, "V7 version %s (c) Cesanta Software, built on %s\n",
           V7_VERSION, __DATE__);
@@ -12017,6 +12013,9 @@ int main(int argc, char *argv[]) {
 
 
 #if V7_ENABLE__Date
+
+#include <locale.h>
+#include <time.h>
 
 #ifdef __APPLE__
 int64_t strtoll(const char *, char **, int);


### PR DESCRIPTION
* Move some includes down to modules where they are used
* Disable date-related functions in minimal profile

Result is still way too big:
Sketch uses 110,568 bytes (342%) of program storage space. Maximum is
32,256 bytes.
Global variables use 5,281 bytes (257%) of dynamic memory, leaving
-3,233 bytes for local variables. Maximum is 2,048 bytes.

#442

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/v7/472)
<!-- Reviewable:end -->
