### PR TITLE
Remove static assert by using explicit size

### DIFF
--- a/v7.c
+++ b/v7.c
@@ -5819,7 +5819,7 @@ int main(void) {
  */
 
 
-typedef unsigned short ast_skip_t;
+typedef uint16_t ast_skip_t;
 
 #ifndef V7_DISABLE_AST_TAG_NAMES
 #define AST_ENTRY(a, b, c, d, e) \
@@ -6234,8 +6234,6 @@ ast_insert_node(struct ast *a, ast_off_t start, enum ast_tag tag) {
 
   return start + 1;
 }
-
-V7_STATIC_ASSERT(sizeof(ast_skip_t) == 2, ast_skip_t_len_should_be_2);
 
 /*
  * Patches a given skip slot for an already emitted node with the


### PR DESCRIPTION
Instead of asserting the size of "unsigned short", we can use "uint16_t".

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/v7/495)
<!-- Reviewable:end -->
