### PR TITLE
Improved String.prototype.split() : added String-based support, fixed a couple of issues

### DIFF
--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -299,6 +299,9 @@ static const char *test_stdlib(void) {
   ASSERT_EVAL_STR_EQ(v7, "m[0]", "a");
   ASSERT_EQ(eval(v7, &v, "m[1]"), V7_OK);
   ASSERT(v7_is_undefined(v));
+  ASSERT_EVAL_NUM_EQ(v7, "m = '123'.split(RegExp('.')); m.length", 4.0);
+  ASSERT_EVAL_NUM_EQ(v7, "m = ''.split(RegExp('')); m.length", 0.0);
+  ASSERT_EVAL_NUM_EQ(v7, "m = ''.split(RegExp('.')); m.length", 1.0);
   ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(' '); m.length", 3.0);
   ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(' ', 2); m.length", 2.0);
   ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(/ /, 2); m.length", 2.0);

--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -337,6 +337,11 @@ static const char *test_stdlib(void) {
   ASSERT_EVAL_STR_EQ(v7, "m[0]", "a");
   ASSERT_EQ(eval(v7, &v, "m[1]"), V7_OK);
   ASSERT(v7_is_undefined(v));
+
+  /* TODO(dfrank): if we remove this test, then other tests start behave
+   * in a weird way: for example, "'123'.split('23');" evaluates to "{}" */
+  ASSERT_EVAL_EQ(v7, "'123'.split('123');", "[\"\",\"\"]");
+
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('.'));", "['','','','']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp(''));", "['1','2','3']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('1'));", "['','23']");
@@ -346,6 +351,16 @@ static const char *test_stdlib(void) {
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('4*'));", "['1','2','3']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "''.split(RegExp(''));", "[]");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "''.split(RegExp('.'));", "['']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('1');", "['','23']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('2');", "['1','3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('3');", "['12','']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('12');", "['','3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('23');", "['1','']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('123');", "['','']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('1234');", "['123']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('');", "['1','2','3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'111'.split('1');", "['','','','']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'12.34.56'.split('.');", "['12','34','56']");
   ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(' '); m.length", 3.0);
   ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(' ', 2); m.length", 2.0);
   ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(/ /, 2); m.length", 2.0);

--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -354,6 +354,14 @@ static const char *test_stdlib(void) {
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('3*'));", "['1','2','']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('2*'));", "['1','3']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('4*'));", "['1','2','3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('2*'), 1);", "['1']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('2*'), 2);", "['1','3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('2*'), 3);", "['1','3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('2*'), 4);", "['1','3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('4*'), 1);", "['1']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('4*'), 2);", "['1','2']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('4*'), 3);", "['1','2','3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('4*'), 4);", "['1','2','3']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(/.*/);", "['', '']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/.*/);", "['', '']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'12345'.split(/.*/);", "['', '']");
@@ -383,6 +391,24 @@ static const char *test_stdlib(void) {
       "['', '4', '']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'ab12 cd34'.split(/([a-z]*)(\\d*)/);",
       "['', 'ab', '12', ' ', 'cd', '34', '']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(x)*/, 0);",
+      "[]");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(x)*/, 1);",
+      "['1']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(x)*/, 2);",
+      "['1', undefined]");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(x)*/, 3);",
+      "['1', undefined, '2']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(x)*/, 4);",
+      "['1', undefined, '2', undefined]");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(x)*/, 5);",
+      "['1', undefined, '2', undefined, '3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(x)*/, 6);",
+      "['1', undefined, '2', undefined, '3', undefined]");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(x)*/, 7);",
+      "['1', undefined, '2', undefined, '3', undefined, '4']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(x)*/, 8);",
+      "['1', undefined, '2', undefined, '3', undefined, '4']");
   ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(' '); m.length", 3.0);
   ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(' ', 2); m.length", 2.0);
   ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(/ /, 2); m.length", 2.0);

--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -337,8 +337,6 @@ static const char *test_stdlib(void) {
   ASSERT_EVAL_OK(v7, "m = 'should match empty string at index 0'.match(/x*/)");
   ASSERT_EVAL_NUM_EQ(v7, "m.length", 1.0);
   ASSERT_EVAL_STR_EQ(v7, "m[0]", "");
-  ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(); m.length", 1.0);
-  ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(''); m.length", 8.0);
   ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(RegExp('')); m.length", 8.0);
   ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(/x*/); m.length", 8.0);
   ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(/(x)*/); m.length", 15.0);
@@ -368,19 +366,6 @@ static const char *test_stdlib(void) {
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'123456'.split(/.*/);", "['', '']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "''.split(RegExp(''));", "[]");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "''.split(RegExp('.'));", "['']");
-  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('1');", "['','23']");
-  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('2');", "['1','3']");
-  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('3');", "['12','']");
-  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('12');", "['','3']");
-  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('23');", "['1','']");
-  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('123');", "['','']");
-  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('1234');", "['123']");
-  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('');", "['1','2','3']");
-  ASSERT_EVAL_JS_EXPR_EQ(v7, "'111'.split('1');", "['','','','']");
-  ASSERT_EVAL_JS_EXPR_EQ(v7, "'абв'.split('б');", "['а','в']");
-  ASSERT_EVAL_JS_EXPR_EQ(v7, "'абв'.split('');", "['а','б','в']");
-  ASSERT_EVAL_JS_EXPR_EQ(v7, "'rбв'.split('');", "['r','б','в']");
-  ASSERT_EVAL_JS_EXPR_EQ(v7, "'12.34.56'.split('.');", "['12','34','56']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(x)*/);",
       "['1', undefined, '2', undefined, '3', undefined, '4']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(2)*/);",
@@ -409,11 +394,7 @@ static const char *test_stdlib(void) {
       "['1', undefined, '2', undefined, '3', undefined, '4']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(x)*/, 8);",
       "['1', undefined, '2', undefined, '3', undefined, '4']");
-  ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(' '); m.length", 3.0);
-  ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(' ', 2); m.length", 2.0);
   ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(/ /, 2); m.length", 2.0);
-  ASSERT_EVAL_NUM_EQ(v7, "'aa bb cc'.substr(0, 4).split(' ').length", 2.0);
-  ASSERT_EVAL_STR_EQ(v7, "'aa bb cc'.substr(0, 4).split(' ')[1]", "b");
   ASSERT_EVAL_NUM_EQ(
       v7, "({z: '123456'}).z.toString().substr(0, 3).split('').length", 3.0);
   c = "\"a\\nb\".replace(/\\n/g, \"\\\\\");";
@@ -421,6 +402,27 @@ static const char *test_stdlib(void) {
   c = "\"\"";
   ASSERT_EVAL_EQ(v7, "'abc'.replace(/.+/, '')", c);
 #endif /* V7_ENABLE__RegExp */
+
+  ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(); m.length", 1.0);
+  ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(''); m.length", 8.0);
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('1');", "['','23']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('2');", "['1','3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('3');", "['12','']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('12');", "['','3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('23');", "['1','']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('123');", "['','']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('1234');", "['123']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('');", "['1','2','3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'111'.split('1');", "['','','','']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'абв'.split('б');", "['а','в']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'абв'.split('');", "['а','б','в']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'rбв'.split('');", "['r','б','в']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'12.34.56'.split('.');", "['12','34','56']");
+  ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(' '); m.length", 3.0);
+  ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(' ', 2); m.length", 2.0);
+  ASSERT_EVAL_NUM_EQ(v7, "'aa bb cc'.substr(0, 4).split(' ').length", 2.0);
+  ASSERT_EVAL_STR_EQ(v7, "'aa bb cc'.substr(0, 4).split(' ')[1]", "b");
+
   ASSERT_EVAL_STR_EQ(v7, "String('hi')", "hi");
   ASSERT_EVAL_OK(v7, "new String('blah')");
   ASSERT_EVAL_NUM_EQ(v7, "(String.fromCharCode(0,1) + '\\x00\\x01').length", 4);

--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -354,6 +354,10 @@ static const char *test_stdlib(void) {
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('3*'));", "['1','2','']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('2*'));", "['1','3']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('4*'));", "['1','2','3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(/.*/);", "['', '']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/.*/);", "['', '']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'12345'.split(/.*/);", "['', '']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123456'.split(/.*/);", "['', '']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "''.split(RegExp(''));", "[]");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "''.split(RegExp('.'));", "['']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('1');", "['','23']");

--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -341,16 +341,18 @@ static const char *test_stdlib(void) {
   ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(''); m.length", 8.0);
   ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(RegExp('')); m.length", 8.0);
   ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(/x*/); m.length", 8.0);
-  ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(/(x)*/); m.length", 16.0);
+  ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(/(x)*/); m.length", 15.0);
   ASSERT_EVAL_STR_EQ(v7, "m[0]", "a");
   ASSERT_EQ(eval(v7, &v, "m[1]"), V7_OK);
   ASSERT(v7_is_undefined(v));
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('.'));", "['','','','']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp(''));", "['1','2','3']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('1'));", "['','23']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('2'));", "['1','3']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('3'));", "['12','']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('1*'));", "['','2','3']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('3*'));", "['1','2','']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('2*'));", "['1','3']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('4*'));", "['1','2','3']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "''.split(RegExp(''));", "[]");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "''.split(RegExp('.'));", "['']");
@@ -367,6 +369,16 @@ static const char *test_stdlib(void) {
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'абв'.split('');", "['а','б','в']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'rбв'.split('');", "['r','б','в']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'12.34.56'.split('.');", "['12','34','56']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(x)*/);",
+      "['1', undefined, '2', undefined, '3', undefined, '4']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(2)*/);",
+      "['1', '2', '3', undefined, '4']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(\\d)/);",
+      "['', '1', '', '2', '', '3', '', '4', '']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(\\d)*/);",
+      "['', '4', '']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'ab12 cd34'.split(/([a-z]*)(\\d*)/);",
+      "['', 'ab', '12', ' ', 'cd', '34', '']");
   ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(' '); m.length", 3.0);
   ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(' ', 2); m.length", 2.0);
   ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(/ /, 2); m.length", 2.0);

--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -360,6 +360,9 @@ static const char *test_stdlib(void) {
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('1234');", "['123']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('');", "['1','2','3']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'111'.split('1');", "['','','','']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'абв'.split('б');", "['а','в']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'абв'.split('');", "['а','б','в']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'rбв'.split('');", "['r','б','в']");
   ASSERT_EVAL_JS_EXPR_EQ(v7, "'12.34.56'.split('.');", "['12','34','56']");
   ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(' '); m.length", 3.0);
   ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(' ', 2); m.length", 2.0);

--- a/v7.c
+++ b/v7.c
@@ -17176,7 +17176,7 @@ static val_t Str_split(struct v7 *v7) {
         }
 
         /* advance lookup_idx appropriately */
-        if (ctx.match_start == ctx.match_end){
+        if (last_match_len == 0){
           /* empty match: advance to the next char */
           const char *next = utfnshift((char *)(s + lookup_idx), 1);
           lookup_idx += (next - (s + lookup_idx));

--- a/v7.c
+++ b/v7.c
@@ -17148,7 +17148,7 @@ static val_t Str_split(struct v7 *v7) {
 
     if (s_len == 0){
       /* if `this` is (or converts to) an empty string, resulting array should
-       * contain empty string if only separator matches empty string.
+       * contain empty string if only separator does not match an empty string.
        * Otherwise, the array is left empty */
       if (!matches_empty){
         v7_array_push(v7, res, this_obj);

--- a/v7.c
+++ b/v7.c
@@ -17155,8 +17155,15 @@ static val_t Str_split(struct v7 *v7) {
         if (ctx.p_exec(&ctx, s + shift, s_end)) break;
         if (ctx.match_start == ctx.match_end)
         {
-          tmp_s = v7_create_string(v7, s + shift, 1, 1);
-          shift++;
+          /* empty match: add one-symbol string */
+          size_t symb_width = 1;
+          {
+            const char *next = utfnshift((char *)(s + shift), 1);
+            symb_width = next - (s + shift);
+          }
+
+          tmp_s = v7_create_string(v7, s + shift, symb_width, 1);
+          shift += symb_width;
         } else {
           tmp_s =
             v7_create_string(v7, s + shift, ctx.match_start - s - shift, 1);

--- a/v7.c
+++ b/v7.c
@@ -16535,7 +16535,7 @@ static int subs_string_exec(
  * This is an empty stub function; only RegExp has an implementation (see above)
  */
 static void subs_string_split_add_caps(
-    struct _str_split_ctx *ctx, val_t res)
+    struct _str_split_ctx UNUSED *ctx, val_t UNUSED res)
 {
 }
 


### PR DESCRIPTION
As the title suggests, if the separator given to `String.prototype.split()` is anything but RegExp, it is interpreted as String, and source string gets splitted by the plain string instead of RegExp. It works if v7 is built without RegExp support.

In addition, a couple of issues fixed, so that behavior of `String.prototype.split()` is now identical to that of browsers (Firefox, Chrome, Opera)

#### 1:

Accordingly to spec, if pattern does not match an empty string, then the empty substring at the end of the source string should be included in the resulting array:

  - `'123'.split(RegExp('.'))` should evaluate to `[ '', '', '', '' ]`, but previously it evaluated to `[ '', '', '' ]`.
  - `'123'.split(/2*/)` should evaluate to `['1', '3']`, but previously it evaluated to `['1', '', '3']`

#### 2:

Accordingly to spec, `''.split(/.*/)` should evaluate to `[]`, not `[ '' ]`, since given pattern matches an empty string.

Details in spec: http://www.ecma-international.org/ecma-262/5.1/#sec-15.5.4.14

#### 3:

Non-ASCII strings were not handled correctly: for example, `'абв'.split(RegExp(''))` should evaluate to `["а","б","в"]`, but previously it evaluated to `["�","�","�","�","�","�"]`

#### 4:

When the pattern contains capture groups, resulting array contained extra items:

  - `'123'.split(/(x)*/)` should evaluate to `["1",undefined,"2",undefined,"3"]`, but previously it evaluated to `["1",undefined,"2",undefined,"3",undefined]` (notice an extra trailing `undefined`)

#### 5:

Limit wasn't handled correctly. For example, `'123'.split(/(x)*/, 2)` should evaluate to `["1",undefined]`, but it evaluated to `["1",undefined,"2",undefined]`

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/v7/510)
<!-- Reviewable:end -->
