### PR TITLE
Fixes issue #217: there was a bug in to_str() with function declarations

### DIFF
--- a/v7.c
+++ b/v7.c
@@ -8108,7 +8108,8 @@ V7_PRIVATE int to_str(struct v7 *v7, val_t v, char *buf, size_t size,
           var_end = ast_get_skip(a, var, AST_END_SKIP);
           ast_move_to_children(a, &var);
           while (var < var_end) {
-            V7_CHECK(v7, ast_fetch_tag(a, &var) == AST_VAR_DECL);
+            enum ast_tag tag = ast_fetch_tag(a, &var);
+            V7_CHECK(v7, tag == AST_VAR_DECL || tag == AST_FUNC_DECL);
             name = ast_get_inlined_data(a, var, &name_len);
             ast_move_to_children(a, &var);
             ast_skip_tree(a, &var);


### PR DESCRIPTION
`to_str()` wasn't expecting anything but `VAR_DECL`, although there might as well be a `FUNC_DECL`. Resolves issue #217.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/v7/511)
<!-- Reviewable:end -->
