### PR TITLE
Improved String.prototype.split() : added String-based support, fixed a couple of issues

### DIFF
--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -89,6 +89,50 @@ static int check_value(struct v7 *v7, val_t v, const char *str) {
   return res;
 }
 
+static int check_js_expr(struct v7 *v7, val_t v_actual,
+                         const char *expect_js_expr) {
+  int res = 1;
+  v7_val_t v_expect;
+  enum v7_err e;
+
+  v7_own(v7, &v_actual);
+
+  /* execute expected value */
+  e = v7_exec(v7, expect_js_expr, &v_expect);
+  v7_own(v7, &v_expect);
+
+  if (e != V7_OK) {
+    /* failed to execute expected value */
+    printf("Exec expected '%s' failed, err=%d\n", expect_js_expr, e);
+    res = 0;
+  } else {
+    /* now, stringify both values (actual and expected) and compare them */
+
+    char buf_actual[2048];
+    char *p_actual = v7_to_json(v7, v_actual, buf_actual, sizeof(buf_actual));
+
+    char buf_expect[2048];
+    char *p_expect = v7_to_json(v7, v_expect, buf_expect, sizeof(buf_expect));
+
+    if (strcmp(p_actual, p_expect) != 0) {
+      _strfail(p_actual, p_expect, -1);
+      res = 0;
+    }
+    if (p_actual != buf_actual) {
+      free(p_actual);
+    }
+
+    if (p_expect != buf_expect) {
+      free(p_expect);
+    }
+  }
+
+  v7_disown(v7, &v_expect);
+  v7_disown(v7, &v_actual);
+
+  return res;
+}
+
 static int check_num(struct v7 *v7, val_t v, double num) {
   int ret = isnan(num) ? isnan(v7_to_number(v)) : v7_to_number(v) == num;
   (void) v7;
@@ -155,6 +199,8 @@ static int test_if_expr(struct v7 *v7, const char *expr, int result) {
 
 #define ASSERT_EVAL_EQ(v7, js_expr, expected) \
   _ASSERT_EVAL_EQ(v7, js_expr, expected, check_value)
+#define ASSERT_EVAL_JS_EXPR_EQ(v7, js_expr, expected) \
+  _ASSERT_EVAL_EQ(v7, js_expr, expected, check_js_expr)
 #define ASSERT_EVAL_NUM_EQ(v7, js_expr, expected) \
   _ASSERT_EVAL_EQ(v7, js_expr, expected, check_num)
 #define ASSERT_EVAL_STR_EQ(v7, js_expr, expected) \
@@ -294,19 +340,64 @@ static const char *test_stdlib(void) {
   ASSERT_EVAL_OK(v7, "m = 'should match empty string at index 0'.match(/x*/)");
   ASSERT_EVAL_NUM_EQ(v7, "m.length", 1.0);
   ASSERT_EVAL_STR_EQ(v7, "m[0]", "");
-  ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(); m.length", 1.0);
-  ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(''); m.length", 8.0);
   ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(RegExp('')); m.length", 8.0);
   ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(/x*/); m.length", 8.0);
-  ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(/(x)*/); m.length", 16.0);
+  ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(/(x)*/); m.length", 15.0);
   ASSERT_EVAL_STR_EQ(v7, "m[0]", "a");
   ASSERT_EQ(eval(v7, &v, "m[1]"), V7_OK);
   ASSERT(v7_is_undefined(v));
-  ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(' '); m.length", 3.0);
-  ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(' ', 2); m.length", 2.0);
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('.'));", "['','','','']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp(''));", "['1','2','3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('1'));", "['','23']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('2'));", "['1','3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('3'));", "['12','']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('1*'));", "['','2','3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('3*'));", "['1','2','']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('2*'));", "['1','3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('4*'));", "['1','2','3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('2*'), 1);", "['1']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('2*'), 2);", "['1','3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('2*'), 3);", "['1','3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('2*'), 4);", "['1','3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('4*'), 1);", "['1']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('4*'), 2);", "['1','2']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('4*'), 3);", "['1','2','3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(RegExp('4*'), 4);", "['1','2','3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split(/.*/);", "['', '']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/.*/);", "['', '']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'12345'.split(/.*/);", "['', '']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123456'.split(/.*/);", "['', '']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "''.split(RegExp(''));", "[]");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "''.split(RegExp('.'));", "['']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(x)*/);",
+      "['1', undefined, '2', undefined, '3', undefined, '4']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(2)*/);",
+      "['1', '2', '3', undefined, '4']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(\\d)/);",
+      "['', '1', '', '2', '', '3', '', '4', '']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(\\d)*/);",
+      "['', '4', '']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'ab12 cd34'.split(/([a-z]*)(\\d*)/);",
+      "['', 'ab', '12', ' ', 'cd', '34', '']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(x)*/, 0);",
+      "[]");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(x)*/, 1);",
+      "['1']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(x)*/, 2);",
+      "['1', undefined]");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(x)*/, 3);",
+      "['1', undefined, '2']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(x)*/, 4);",
+      "['1', undefined, '2', undefined]");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(x)*/, 5);",
+      "['1', undefined, '2', undefined, '3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(x)*/, 6);",
+      "['1', undefined, '2', undefined, '3', undefined]");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(x)*/, 7);",
+      "['1', undefined, '2', undefined, '3', undefined, '4']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'1234'.split(/(x)*/, 8);",
+      "['1', undefined, '2', undefined, '3', undefined, '4']");
   ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(/ /, 2); m.length", 2.0);
-  ASSERT_EVAL_NUM_EQ(v7, "'aa bb cc'.substr(0, 4).split(' ').length", 2.0);
-  ASSERT_EVAL_STR_EQ(v7, "'aa bb cc'.substr(0, 4).split(' ')[1]", "b");
   ASSERT_EVAL_NUM_EQ(
       v7, "({z: '123456'}).z.toString().substr(0, 3).split('').length", 3.0);
   c = "\"a\\nb\".replace(/\\n/g, \"\\\\\");";
@@ -314,6 +405,27 @@ static const char *test_stdlib(void) {
   c = "\"\"";
   ASSERT_EVAL_EQ(v7, "'abc'.replace(/.+/, '')", c);
 #endif /* V7_ENABLE__RegExp */
+
+  ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(); m.length", 1.0);
+  ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(''); m.length", 8.0);
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('1');", "['','23']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('2');", "['1','3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('3');", "['12','']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('12');", "['','3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('23');", "['1','']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('123');", "['','']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('1234');", "['123']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'123'.split('');", "['1','2','3']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'111'.split('1');", "['','','','']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'абв'.split('б');", "['а','в']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'абв'.split('');", "['а','б','в']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'rбв'.split('');", "['r','б','в']");
+  ASSERT_EVAL_JS_EXPR_EQ(v7, "'12.34.56'.split('.');", "['12','34','56']");
+  ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(' '); m.length", 3.0);
+  ASSERT_EVAL_NUM_EQ(v7, "m = 'aa bb cc'.split(' ', 2); m.length", 2.0);
+  ASSERT_EVAL_NUM_EQ(v7, "'aa bb cc'.substr(0, 4).split(' ').length", 2.0);
+  ASSERT_EVAL_STR_EQ(v7, "'aa bb cc'.substr(0, 4).split(' ')[1]", "b");
+
   ASSERT_EVAL_STR_EQ(v7, "String('hi')", "hi");
   ASSERT_EVAL_OK(v7, "new String('blah')");
   ASSERT_EVAL_NUM_EQ(v7, "(String.fromCharCode(0,1) + '\\x00\\x01').length", 4);

--- a/v7.c
+++ b/v7.c
@@ -16862,6 +16862,163 @@ V7_PRIVATE void init_math(struct v7 *v7) {
 
 V7_PRIVATE val_t to_string(struct v7 *, val_t);
 
+/* Substring implementations: RegExp-based and String-based {{{ */
+
+/*
+ * Substring context: currently, used in Str_split() only, but will probably
+ * be used in Str_replace() and other functions as well.
+ *
+ * Needed to provide different implementation for RegExp or String arguments,
+ * keeping common parts reusable.
+ */
+struct _str_split_ctx {
+  /* implementation-specific data */
+  union {
+#if V7_ENABLE__RegExp
+    struct {
+      struct slre_prog *prog;
+      struct slre_loot loot;
+    } regexp;
+#endif
+
+    struct {
+      val_t sep;
+    } string;
+  } impl;
+
+  struct v7 *v7;
+
+  /* start and end of previous match (set by `p_exec()`) */
+  const char *match_start;
+  const char *match_end;
+
+  /* pointers to implementation functions */
+
+  /*
+   * Initialize context
+   */
+  void (*p_init)(struct _str_split_ctx *ctx, struct v7 *v7, val_t sep);
+
+  /*
+   * Look for the next match, set `match_start` and `match_end` to appropriate
+   * values.
+   *
+   * Returns 0 if match found, 1 otherwise (in accordance with `slre_exec()`)
+   */
+  int  (*p_exec)(struct _str_split_ctx *ctx,
+                 const char *start, const char *end);
+
+#if V7_ENABLE__RegExp
+  /*
+   * Add captured data to resulting array (for RegExp-based implementation only)
+   *
+   * Returns updated `elem` value
+   */
+  long (*p_add_caps)(struct _str_split_ctx *ctx, val_t res,
+                     long elem, long limit);
+#endif
+};
+
+#if V7_ENABLE__RegExp
+/* RegExp-based implementation of `p_init` in `struct _str_split_ctx` */
+static void subs_regexp_init(
+    struct _str_split_ctx *ctx, struct v7 *v7, val_t sep)
+{
+  ctx->v7 = v7;
+  ctx->impl.regexp.prog = v7_to_regexp(v7, sep)->compiled_regexp;
+}
+
+/* RegExp-based implementation of `p_exec` in `struct _str_split_ctx` */
+static int subs_regexp_exec(
+    struct _str_split_ctx *ctx, const char *start, const char *end)
+{
+  int ret =
+    slre_exec(ctx->impl.regexp.prog, 0, start, end, &ctx->impl.regexp.loot);
+
+  ctx->match_start = ctx->impl.regexp.loot.caps[0].start;
+  ctx->match_end   = ctx->impl.regexp.loot.caps[0].end;
+
+  return ret;
+}
+
+/* RegExp-based implementation of `p_add_caps` in `struct _str_split_ctx` */
+static long subs_regexp_split_add_caps(
+    struct _str_split_ctx *ctx, val_t res,
+    long elem, long limit)
+{
+  int i;
+  for (i = 1; i < ctx->impl.regexp.loot.num_captures && elem < limit; i++) {
+    size_t cap_len =
+      ctx->impl.regexp.loot.caps[i].end - ctx->impl.regexp.loot.caps[i].start;
+    v7_array_push(
+        ctx->v7, res,
+        (ctx->impl.regexp.loot.caps[i].start != NULL)
+           ? v7_create_string(ctx->v7, ctx->impl.regexp.loot.caps[i].start,
+                              cap_len, 1)
+           : v7_create_undefined()
+        );
+    elem++;
+  }
+  return elem;
+}
+#endif
+
+/* String-based implementation of `p_init` in `struct _str_split_ctx` */
+static void subs_string_init(
+    struct _str_split_ctx *ctx, struct v7 *v7, val_t sep)
+{
+  ctx->v7 = v7;
+  ctx->impl.string.sep = sep;
+}
+
+/* String-based implementation of `p_exec` in `struct _str_split_ctx` */
+static int subs_string_exec(
+    struct _str_split_ctx *ctx, const char *start, const char *end)
+{
+  int ret = 1;
+  size_t sep_len;
+  const char *psep = v7_to_string(ctx->v7, &ctx->impl.string.sep, &sep_len);
+
+  if (sep_len == 0){
+    /* separator is an empty string: match empty string */
+    ctx->match_start = start;
+    ctx->match_end   = start;
+    ret = 0;
+  } else {
+    size_t i;
+    for (
+        i = 0;
+        start <= (end - sep_len);
+        ++i, start = utfnshift((char *) start, 1)
+        )
+    {
+      if (memcmp(start, psep, sep_len) == 0) {
+        ret = 0;
+        ctx->match_start = start;
+        ctx->match_end   = start + sep_len;
+        break;
+      }
+    }
+  }
+
+  return ret;
+}
+
+#if V7_ENABLE__RegExp
+/* String-based implementation of `p_add_caps` in `struct _str_split_ctx` */
+static long subs_string_split_add_caps(
+    struct _str_split_ctx UNUSED *ctx, val_t UNUSED res,
+    long elem, long UNUSED limit)
+{
+  /* this is a stub function */
+  return elem;
+}
+#endif
+
+/* }}} */
+
+
+
 static val_t String_ctor(struct v7 *v7) {
   val_t this_obj = v7_get_this(v7);
   val_t arg0 = v7_arg(v7, 0), res = arg0;
@@ -17409,63 +17566,121 @@ static val_t Str_substring(struct v7 *v7) {
   return s_substr(v7, this_obj, start, end - start);
 }
 
-/* TODO(mkm): make an alternative implementation without regexps */
-#if V7_ENABLE__RegExp
 static val_t Str_split(struct v7 *v7) {
   val_t this_obj = v7_get_this(v7);
   val_t res = v7_create_dense_array(v7);
   const char *s, *s_end;
   size_t s_len;
   long num_args = v7_argc(v7);
-  struct slre_prog *prog = NULL;
   this_obj = to_string(v7, this_obj);
   s = v7_to_string(v7, &this_obj, &s_len);
   s_end = s + s_len;
 
-  if (num_args == 0 || s_len == 0) {
+  if (num_args == 0) {
+    /*
+     * No arguments were given: resulting array will contain just a single
+     * element: the source string
+     */
     v7_array_push(v7, res, this_obj);
   } else {
     val_t ro = i_value_of(v7, v7_arg(v7, 0));
-    long len, elem = 0, limit = arg_long(v7, 1, LONG_MAX);
-    size_t shift = 0;
-    struct slre_loot loot;
-    if (!v7_is_regexp(v7, ro)) {
-      ro = call_regex_ctor(v7, ro);
-    }
-    prog = v7_to_regexp(v7, ro)->compiled_regexp;
+    long elem, limit = arg_long(v7, 1, LONG_MAX);
+    size_t lookup_idx = 0, substr_idx = 0;
+    struct _str_split_ctx ctx;
 
-    for (; elem < limit && shift < s_len; elem++) {
-      val_t tmp_s;
-      int i;
-      if (slre_exec(prog, 0, s + shift, s_end, &loot)) break;
-      if (loot.caps[0].end - loot.caps[0].start == 0) {
-        tmp_s = v7_create_string(v7, s + shift, 1, 1);
-        shift++;
-      } else {
-        tmp_s =
-            v7_create_string(v7, s + shift, loot.caps[0].start - s - shift, 1);
-        shift = loot.caps[0].end - s;
-      }
-      v7_array_push(v7, res, tmp_s);
+    /* Initialize substring context depending on the argument type */
+    if (v7_is_regexp(v7, ro)) {
+      /* use RegExp implementation */
+#if V7_ENABLE__RegExp
+      ctx.p_init = subs_regexp_init;
+      ctx.p_exec = subs_regexp_exec;
+      ctx.p_add_caps = subs_regexp_split_add_caps;
+#else
+      assert(0);
+#endif
+    } else {
+      /*
+       * use String implementation: first of all, convert to String (if it's
+       * not already a String)
+       */
+      ro = to_string(v7, ro);
 
-      for (i = 1; i < loot.num_captures; i++) {
-        v7_array_push(
-            v7, res,
-            (loot.caps[i].start != NULL)
-                ? v7_create_string(v7, loot.caps[i].start,
-                                   loot.caps[i].end - loot.caps[i].start, 1)
-                : v7_create_undefined());
-      }
+      ctx.p_init = subs_string_init;
+      ctx.p_exec = subs_string_exec;
+#if V7_ENABLE__RegExp
+      ctx.p_add_caps = subs_string_split_add_caps;
+#endif
     }
-    len = s_len - shift;
-    if (len > 0 && elem < limit) {
-      v7_array_push(v7, res, v7_create_string(v7, s + shift, len, 1));
+    /* initialize context */
+    ctx.p_init(&ctx, v7, ro);
+
+
+    if (s_len == 0){
+      /*
+       * if `this` is (or converts to) an empty string, resulting array should
+       * contain empty string if only separator does not match an empty string.
+       * Otherwise, the array is left empty
+       */
+      int matches_empty = !ctx.p_exec(&ctx, s, s);
+      if (!matches_empty){
+        v7_array_push(v7, res, this_obj);
+      }
+    } else {
+      size_t last_match_len = 0;
+
+      for (elem = 0; elem < limit && lookup_idx < s_len; ) {
+        size_t substr_len;
+        /* find next match, and break if there's no match */
+        if (ctx.p_exec(&ctx, s + lookup_idx, s_end)) break;
+
+        last_match_len = ctx.match_end - ctx.match_start;
+        substr_len = ctx.match_start - s - substr_idx;
+
+        /* add next substring to the resulting array, if needed */
+        if (substr_len > 0 || last_match_len > 0) {
+          v7_array_push(
+              v7, res, v7_create_string(v7, s + substr_idx, substr_len, 1)
+              );
+          elem++;
+
+#if V7_ENABLE__RegExp
+          /* Add captures (for RegExp only) */
+          elem = ctx.p_add_caps(&ctx, res, elem, limit);
+#endif
+        }
+
+        /* advance lookup_idx appropriately */
+        if (last_match_len == 0){
+          /* empty match: advance to the next char */
+          const char *next = utfnshift((char *)(s + lookup_idx), 1);
+          lookup_idx += (next - (s + lookup_idx));
+        } else {
+          /* non-empty match: advance to the end of match */
+          lookup_idx = ctx.match_end - s;
+        }
+
+        /*
+         * always remember the end of the match, so that next time we will take
+         * substring from that position
+         */
+        substr_idx = ctx.match_end - s;
+      }
+
+      /* add the last substring to the resulting array, if needed */
+      if (elem < limit){
+        size_t substr_len = s_len - substr_idx;
+        if (substr_len > 0 || last_match_len > 0) {
+          v7_array_push(
+              v7, res, v7_create_string(v7, s + substr_idx, substr_len, 1)
+              );
+        }
+      }
+
     }
   }
 
   return res;
 }
-#endif /* V7_ENABLE__RegExp */
 
 V7_PRIVATE void init_string(struct v7 *v7) {
   val_t str = v7_create_constructor(v7, v7->string_prototype, String_ctor, 1);
@@ -17488,8 +17703,8 @@ V7_PRIVATE void init_string(struct v7 *v7) {
   set_cfunc_prop(v7, v7->string_prototype, "match", Str_match);
   set_cfunc_prop(v7, v7->string_prototype, "replace", Str_replace);
   set_cfunc_prop(v7, v7->string_prototype, "search", Str_search);
-  set_cfunc_prop(v7, v7->string_prototype, "split", Str_split);
 #endif
+  set_cfunc_prop(v7, v7->string_prototype, "split", Str_split);
   set_cfunc_prop(v7, v7->string_prototype, "slice", Str_slice);
   set_cfunc_prop(v7, v7->string_prototype, "trim", Str_trim);
   set_cfunc_prop(v7, v7->string_prototype, "toLowerCase", Str_toLowerCase);


### PR DESCRIPTION
As the title suggests, if the separator given to `String.prototype.split()` is anything but RegExp, it is interpreted as String, and source string gets splitted by the plain string instead of RegExp. It works if v7 is built without RegExp support.

In addition, a couple of issues fixed, so that behavior of `String.prototype.split()` is now identical to that of browsers (Firefox, Chrome, Opera)

#### 1:

Accordingly to spec, if pattern does not match an empty string, then the empty substring at the end of the source string should be included in the resulting array:

  - `'123'.split(RegExp('.'))` should evaluate to `[ '', '', '', '' ]`, but previously it evaluated to `[ '', '', '' ]`.
  - `'123'.split(/2*/)` should evaluate to `['1', '3']`, but previously it evaluated to `['1', '', '3']`

#### 2:

Accordingly to spec, `''.split(/.*/)` should evaluate to `[]`, not `[ '' ]`, since given pattern matches an empty string.

Details in spec: http://www.ecma-international.org/ecma-262/5.1/#sec-15.5.4.14

#### 3:

Non-ASCII strings were not handled correctly: for example, `'абв'.split(RegExp(''))` should evaluate to `["а","б","в"]`, but previously it evaluated to `["�","�","�","�","�","�"]`

#### 4:

When the pattern contains capture groups, resulting array contained extra items:

  - `'123'.split(/(x)*/)` should evaluate to `["1",undefined,"2",undefined,"3"]`, but previously it evaluated to `["1",undefined,"2",undefined,"3",undefined]` (notice an extra trailing `undefined`)

#### 5:

Limit wasn't handled correctly. For example, `'123'.split(/(x)*/, 2)` should evaluate to `["1",undefined]`, but it evaluated to `["1",undefined,"2",undefined]`

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/v7/510)
<!-- Reviewable:end -->
