### PR TITLE
Fixed String.prototype.lastIndexOf()

### DIFF
--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -322,6 +322,51 @@ static const char *test_stdlib(void) {
   ASSERT_EVAL_NUM_EQ(v7, "'hi there'.indexOf('e', 8)", -1.0);
   ASSERT_EVAL_NUM_EQ(v7, "'aabb'.indexOf('a', false)", 0.0);
   ASSERT_EVAL_NUM_EQ(v7, "'aabb'.indexOf('a', true)", 1.0);
+
+  ASSERT_EVAL_NUM_EQ(v7, "'1234д6 1234д6'.indexOf('34д')", 2.0);
+  ASSERT_EVAL_NUM_EQ(v7, "'1234д6 1234д6'.indexOf('34д', 2)", 2.0);
+  ASSERT_EVAL_NUM_EQ(v7, "'1234д6 1234д6'.indexOf('34д', 3)", 9.0);
+  ASSERT_EVAL_NUM_EQ(v7, "'1234д6 1234д6'.indexOf('34д', 9)", 9.0);
+  ASSERT_EVAL_NUM_EQ(v7, "'1234д6 1234д6'.indexOf('34д', 10)", -1.0);
+
+  ASSERT_EVAL_NUM_EQ(v7, "'1234д6 1234д6'.lastIndexOf('34д')", 9.0);
+  ASSERT_EVAL_NUM_EQ(v7, "'1234д6 1234д6'.lastIndexOf('34д', 10)", 9.0);
+  ASSERT_EVAL_NUM_EQ(v7, "'1234д6 1234д6'.lastIndexOf('34д', 9)", 9.0);
+  ASSERT_EVAL_NUM_EQ(v7, "'1234д6 1234д6'.lastIndexOf('34д', 8)", 2.0);
+  ASSERT_EVAL_NUM_EQ(v7, "'1234д6 1234д6'.lastIndexOf('34д', 2)", 2.0);
+  ASSERT_EVAL_NUM_EQ(v7, "'1234д6 1234д6'.lastIndexOf('34д', 1)", -1.0);
+
+  ASSERT_EVAL_NUM_EQ(v7, "'123'.indexOf('')", 0.0);
+  ASSERT_EVAL_NUM_EQ(v7, "'123'.indexOf('', 0)", 0.0);
+  ASSERT_EVAL_NUM_EQ(v7, "'123'.indexOf('', -100)", 0.0);
+  ASSERT_EVAL_NUM_EQ(v7, "'123'.indexOf('', 100)", 3.0);
+
+  ASSERT_EVAL_NUM_EQ(v7, "'123'.lastIndexOf('')", 3.0);
+  ASSERT_EVAL_NUM_EQ(v7, "'123'.lastIndexOf('', 0)", 0.0);
+  ASSERT_EVAL_NUM_EQ(v7, "'123'.lastIndexOf('', -100)", 0.0);
+  ASSERT_EVAL_NUM_EQ(v7, "'123'.lastIndexOf('', 100)", 3.0);
+
+  ASSERT_EVAL_NUM_EQ(v7, "''.indexOf('')", 0.0);
+  ASSERT_EVAL_NUM_EQ(v7, "''.indexOf('', 100)", 0.0);
+  ASSERT_EVAL_NUM_EQ(v7, "''.indexOf('', -100)", 0.0);
+
+  ASSERT_EVAL_NUM_EQ(v7, "''.lastIndexOf('')", 0.0);
+  ASSERT_EVAL_NUM_EQ(v7, "''.lastIndexOf('', 100)", 0.0);
+  ASSERT_EVAL_NUM_EQ(v7, "''.lastIndexOf('', -100)", 0.0);
+
+  ASSERT_EVAL_NUM_EQ(v7, "''.indexOf('a')", -1.0);
+  ASSERT_EVAL_NUM_EQ(v7, "''.lastIndexOf('a')", -1.0);
+
+  ASSERT_EVAL_NUM_EQ(v7, "'123'.indexOf('23', 100)", -1.0);
+  ASSERT_EVAL_NUM_EQ(v7, "'123'.indexOf('23', -100)", 1.0);
+  ASSERT_EVAL_NUM_EQ(v7, "'123'.lastIndexOf('23', 100)", 1.0);
+  ASSERT_EVAL_NUM_EQ(v7, "'123'.lastIndexOf('23', -100)", -1.0);
+
+  ASSERT_EVAL_NUM_EQ(v7, "'123'.indexOf('12', 100)", -1.0);
+  ASSERT_EVAL_NUM_EQ(v7, "'123'.indexOf('12', -100)", 0.0);
+  ASSERT_EVAL_NUM_EQ(v7, "'123'.lastIndexOf('12', 100)", 0.0);
+  ASSERT_EVAL_NUM_EQ(v7, "'123'.lastIndexOf('12', -100)", 0.0);
+
   ASSERT_EVAL_STR_EQ(v7, "'hi there'.substr(3, 2)", "th");
   ASSERT_EVAL_STR_EQ(v7, "'hi there'.substring(3, 5)", "th");
   ASSERT_EVAL_STR_EQ(v7, "'hi there'.substr(3)", "there");

--- a/v7.c
+++ b/v7.c
@@ -17276,42 +17276,48 @@ static val_t s_index_of(struct v7 *v7, int last) {
 
   if (!v7_is_undefined(arg0)) {
     const char *p1, *p2, *end;
-    size_t i, n1, n2;
+    size_t i, len1, len2, bytecnt1, bytecnt2;
     val_t sub = to_string(v7, arg0);
     this_obj = to_string(v7, this_obj);
-    p1 = v7_to_string(v7, &this_obj, &n1);
-    p2 = v7_to_string(v7, &sub, &n2);
+    p1 = v7_to_string(v7, &this_obj, &bytecnt1);
+    p2 = v7_to_string(v7, &sub, &bytecnt2);
 
-    if (n2 <= n1) {
-      end = p1 + n1;
-      n1 = utfnlen((char *) p1, n1);
+    if (bytecnt2 <= bytecnt1) {
+      end = p1 + bytecnt1;
+      len1 = utfnlen((char *) p1, bytecnt1);
+      len2 = utfnlen((char *) p2, bytecnt2);
+
       if (v7_argc(v7) > 1) {
+        /* `fromIndex` was provided. Normalize it */
         double d = i_as_num(v7, v7_arg(v7, 1));
         if (isnan(d) || d < 0) {
           d = 0.0;
-        } else if (isinf(d)) {
-          d = n1;
+        } else if (isinf(d) || d > len1) {
+          d = len1;
         }
         fromIndex = d;
-      }
-      if (fromIndex > 0) {
-        if (fromIndex >= n1) return v7_create_number(-1);
-        if (last)
-          end = utfnshift((char *) p1, fromIndex + 1);
-        else
+
+        /* adjust pointers accordingly to `fromIndex` */
+        if (last){
+          char *end_tmp = utfnshift((char *) p1, fromIndex + len2);
+          end = (end_tmp < end) ? end_tmp : end;
+        } else {
           p1 = utfnshift((char *) p1, fromIndex);
-      }
-      if (!last || fromIndex != 0) {
-        if (0 == n2 || end - p1 == 0)
-          res = 0;
-        else {
-          for (i = 0; p1 <= (end - n2); i++, p1 = utfnshift((char *) p1, 1))
-            if (memcmp(p1, p2, n2) == 0) {
-              res = i;
-              if (!last) break;
-            }
         }
       }
+
+      /*
+       * TODO(dfrank): when `last` is set, start from the end and look
+       * backward. We'll need to improve `utfnshift()` for that, so that it can
+       * handle negative offsets.
+       */
+      for (i = 0; p1 <= (end - bytecnt2); i++, p1 = utfnshift((char *) p1, 1)){
+        if (memcmp(p1, p2, bytecnt2) == 0) {
+          res = i;
+          if (!last) break;
+        }
+      }
+
     }
   }
   if (!last && res >= 0) res += fromIndex;


### PR DESCRIPTION
At least, the following is fixed:

- `lastIndexOf()` always returned `-1` if `fromIndex` isn't provided
- if `fromIndex` is more than or equal to the string length, then `-1` was always returned, but we should search the whole string instead
- `'123456'.lastIndexOf('3456', 2)` returned `-1`, but it should return `2`

Added all appropriate unit tests as well.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/v7/513)
<!-- Reviewable:end -->
