### PR TITLE
docs: fix simple typo, varialble -> variable

### DIFF
--- a/v7.c
+++ b/v7.c
@@ -4571,7 +4571,7 @@ enum opcode {
   /*
    * Takes 1 value from the stack and a varint argument -- index of the var name
    * in the literals table. Tries to find the variable in the current scope
-   * chain and assign the value to it. If the varialble is not found -- creates
+   * chain and assign the value to it. If the variable is not found -- creates
    * a new one in the global scope. Pushes the value back to the stack.
    *
    * `( a -- a )`


### PR DESCRIPTION
There is a small typo in v7.c.

Should read `variable` rather than `varialble`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md